### PR TITLE
Fixed visual issue when opening accordions.

### DIFF
--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.html
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.html
@@ -38,7 +38,11 @@
     </div>
   </div>
 
-  <accordion #accordion>
+  <!-- Repaint jsPlumb on every accordion click -->
+
+  <accordion #accordion
+             (click)="repaint()">
+
 
     <!-- PROPERTIES -->
     <accordion-group

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.ts
@@ -154,7 +154,7 @@ export class NodeComponent implements OnInit, AfterViewInit, DoCheck, OnDestroy 
           break;
         }
       }*/
-      setTimeout(() => this.askForRepaint.emit(), 1);
+      this.repaint();
     }
   }
 
@@ -184,6 +184,10 @@ export class NodeComponent implements OnInit, AfterViewInit, DoCheck, OnDestroy 
       (this.longpress) ? $event.preventDefault() : this.connectorEndpointVisible = !this.connectorEndpointVisible;
       this.checkIfNodeInSelection.emit(this.title);
     }
+  }
+
+  private repaint() {
+    setTimeout(() => this.askForRepaint.emit(), 1);
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
Signed-off-by: Josip Ledic <ledicjp@gmail.com>

I added a method that asks the _JsPlumbService_ to repaint all connectors whenever an accordion (such as "properties") is opened/closed via click. Before this change, the JsPlumb connectors (arrows) would remain in place when the div's sizes changed and therefore cause visual errors.