### PR TITLE
Fix

### DIFF
--- a/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.html
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.html
@@ -17,13 +17,21 @@
   </div>
 
   <winery-node *ngFor="let node of allNodeTemplates"
-               [title]="node.id"
-               [name]="node.name"
+               [nodeAttributes]="{
+                properties: node.properties,
+                id: node.id,
+                type: node.type,
+                name: node.name,
+                minInstances: node.minInstances,
+                maxInstances: node.maxInstances,
+                color: node.color,
+                imageUrl: node.imageUrl,
+                documentation: node.documentation,
+                any: node.any,
+                otherAttributes: node.otherAttributes
+               }"
                [needsToBeFlashed]="needsToBeFlashed"
-               [nodeColor]="node.color"
                (sendId)="makeDraggable($event)"
-               [otherAttributes]="node.otherAttributes"
-               [nodeImageUrl]="node.imageUrl"
                [navbarButtonsState]="navbarButtonsState"
                (askForRepaint)="repaintJsPlumb($event)"
                (setDragSource)="setDragSource($event)"

--- a/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.html
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.html
@@ -22,14 +22,14 @@
                [needsToBeFlashed]="needsToBeFlashed"
                [nodeColor]="node.color"
                (sendId)="makeDraggable($event)"
-               [left]="node.otherAttributes.x + 'px'"
-               [top]="node.otherAttributes.y + 'px'"
+               [otherAttributes]="node.otherAttributes"
                [nodeImageUrl]="node.imageUrl"
                [navbarButtonsState]="navbarButtonsState"
                (askForRepaint)="repaintJsPlumb($event)"
                (setDragSource)="setDragSource($event)"
                (closedEndpoint)="closedEndpoint($event)"
                [dragSource]="node.id + 'Endpoint'"
-               (checkFocusNode)="checkFocusNode($event)">
+               (checkFocusNode)="checkFocusNode($event)"
+               (updateAllNodes)="updateAllNodes($event)">
   </winery-node>
 </div>

--- a/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.ts
@@ -110,7 +110,6 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
 
   setButtonsState(currentButtonsState: ButtonsStateModel): void {
     this.navbarButtonsState = currentButtonsState;
-    console.log(this.nodeChildrenArray);
     setTimeout(() => this.repaintJsPlumb(), 1);
     const alignmentButtonLayout = this.navbarButtonsState.buttonsState.layoutButton;
     const alignmentButtonAlignH = this.navbarButtonsState.buttonsState.alignHButton;

--- a/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.ts
@@ -90,7 +90,7 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
         const node = currentNodes.find(el => el.id === this.allNodeTemplates[i].id);
         if (this.allNodeTemplates[i].name !== node.name) {
           const nodeId = this.nodeChildrenIdArray.indexOf(this.allNodeTemplates[i].id);
-          this.nodeChildrenArray[nodeId].name = node.name;
+          this.nodeChildrenArray[nodeId].nodeAttributes.name = node.name;
           this.nodeChildrenArray[nodeId].flash();
           this.allNodeTemplates[i].name = node.name;
         }
@@ -101,13 +101,16 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
 
   updateRelationships(currentRelationships: Array<TRelationshipTemplate>): void {
     this.allRelationshipTemplates = currentRelationships;
-    for (const relationship of this.allRelationshipTemplates) {
-      setTimeout(() => this.displayRelationships(relationship), 1);
+    if (this.allRelationshipTemplates.length > 0) {
+      for (const relationship of this.allRelationshipTemplates) {
+        setTimeout(() => this.displayRelationships(relationship), 1);
+      }
     }
   }
 
   setButtonsState(currentButtonsState: ButtonsStateModel): void {
     this.navbarButtonsState = currentButtonsState;
+    console.log(this.nodeChildrenArray);
     setTimeout(() => this.repaintJsPlumb(), 1);
     const alignmentButtonLayout = this.navbarButtonsState.buttonsState.layoutButton;
     const alignmentButtonAlignH = this.navbarButtonsState.buttonsState.alignHButton;
@@ -147,9 +150,9 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
     this.resetDragSource('reset drag source');
   }
 
-  resetDragSource($event): void {
+  resetDragSource(nodeId: string): void {
     if (this.dragSourceInfos) {
-      if (this.dragSourceInfos.nodeId !== $event) {
+      if (this.dragSourceInfos.nodeId !== nodeId) {
         if (this.newJsPlumbInstance.isSource(this.dragSourceInfos.dragSource)) {
           this.newJsPlumbInstance.unmakeSource(this.dragSourceInfos.dragSource);
         }
@@ -163,28 +166,28 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
     this.dragSourceActive = false;
   }
 
-  closedEndpoint($event): void {
-    const node = this.nodeChildrenArray.find((nodeTemplate => nodeTemplate.title === $event));
+  closedEndpoint(nodeId: string): void {
+    const node = this.nodeChildrenArray.find((nodeTemplate => nodeTemplate.nodeAttributes.id === nodeId));
     node.connectorEndpointVisible = !node.connectorEndpointVisible;
     if (node.connectorEndpointVisible === true) {
       this.dragSourceActive = false;
-      this.resetDragSource($event);
+      this.resetDragSource(nodeId);
       for (const currentNode of this.nodeChildrenArray) {
-        if (currentNode.title !== $event) {
+        if (currentNode.nodeAttributes.id !== nodeId) {
           currentNode.connectorEndpointVisible = false;
         }
       }
     }
   }
 
-  setDragSource($event): void {
+  setDragSource(dragSourceInfo: any): void {
     if (!this.dragSourceActive) {
-      this.newJsPlumbInstance.makeSource($event.dragSource, {
+      this.newJsPlumbInstance.makeSource(dragSourceInfo.dragSource, {
         connectorOverlays: [
           ['Arrow', {location: 1}],
         ],
       });
-      this.dragSourceInfos = $event;
+      this.dragSourceInfos = dragSourceInfo;
       this.newJsPlumbInstance.makeTarget(this.allNodesIds);
       this.dragSourceActive = true;
     }
@@ -194,21 +197,22 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
   handleDeleteKeyEvent(event: KeyboardEvent) {
     for (const node of this.nodeChildrenArray) {
       if (node.makeSelectionVisible === true) {
-        this.newJsPlumbInstance.removeAllEndpoints(node.title);
-        if (this.newJsPlumbInstance.isSource(node.dragSource)) {
-          this.newJsPlumbInstance.unmakeSource(node.dragSource);
+        this.newJsPlumbInstance.removeAllEndpoints(node.nodeAttributes.id);
+        if (node.connectorEndpointVisible === true) {
+          if (this.newJsPlumbInstance.isSource(node.dragSource)) {
+            this.newJsPlumbInstance.unmakeSource(node.dragSource);
+          }
         }
-        this.ngRedux.dispatch(this.actions.deleteNodeTemplate(node.title));
+        this.ngRedux.dispatch(this.actions.deleteNodeTemplate(node.nodeAttributes.id));
       }
     }
-    if (this.allRelationshipTemplates.length === 0) {
-      this.hideSidebar();
-    }
+    this.hideSidebar();
   }
+
 
   clearSelectedNodes(): void {
     for (const node of this.nodeChildrenArray) {
-      if (this.selectedNodes.find(selectedNode => selectedNode.id === node.title)) {
+      if (this.selectedNodes.find(selectedNode => selectedNode.id === node.nodeAttributes.id)) {
         node.makeSelectionVisible = false;
       }
     }
@@ -216,7 +220,7 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
     this.selectedNodes.length = 0;
   }
 
-  showSelectionRange($event) {
+  showSelectionRange($event: any) {
     // mousedown
     this.ngRedux.dispatch(this.actions.sendPaletteOpened(false));
     this.hideSidebar();
@@ -236,7 +240,7 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
     this.crosshair = true;
   }
 
-  openSelector($event) {
+  openSelector($event: any) {
     this.selectionWidth = Math.abs(this.initialW - $event.pageX);
     this.selectionHeight = Math.abs(this.initialH - $event.pageY);
     if ($event.pageX <= this.initialW && $event.pageY >= this.initialH) {
@@ -257,7 +261,7 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
     this.selectElements(ev);
   }
 
-  selectElements($event) {
+  selectElements($event: any) {
     // mouseUp
     for (const node of this.allNodeTemplates) {
       const aElem = document.getElementById('selection');
@@ -289,7 +293,7 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
     this.gridHeight = window.innerHeight;
   }
 
-  private getOffset(el) {
+  private getOffset(el: any) {
     let _x = 0;
     let _y = 0;
     while (el && !isNaN(el.offsetLeft) && !isNaN(el.offsetTop)) {
@@ -300,7 +304,7 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
     return {top: _y, left: _x};
   }
 
-  doObjectsCollide(a, b): boolean {
+  doObjectsCollide(a: any, b: any): boolean {
     const aTop = this.getOffset(a).top;
     const aLeft = this.getOffset(a).left;
     const bTop = this.getOffset(b).top;
@@ -324,38 +328,38 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
     }));
   }
 
-  checkFocusNode($event): void {
-    if ($event.ctrlKey) {
-      if (!this.arrayContainsNode(this.selectedNodes, $event.id)) {
-        this.enhanceDragSelection($event.id);
+  checkFocusNode(focusNodeData: any): void {
+    if (focusNodeData.ctrlKey) {
+      if (!this.arrayContainsNode(this.selectedNodes, focusNodeData.id)) {
+        this.enhanceDragSelection(focusNodeData.id);
         for (const node of this.nodeChildrenArray) {
-          const nodeIndex = this.selectedNodes.map(selectedNode => selectedNode.id).indexOf(node.title);
+          const nodeIndex = this.selectedNodes.map(selectedNode => selectedNode.id).indexOf(node.nodeAttributes.id);
           if (this.selectedNodes[nodeIndex] === undefined) {
             node.makeSelectionVisible = false;
           }
         }
       } else {
-        this.newJsPlumbInstance.removeFromAllPosses($event.id);
-        const nodeIndex = this.nodeChildrenArray.map(node => node.title).indexOf($event.id);
+        this.newJsPlumbInstance.removeFromAllPosses(focusNodeData.id);
+        const nodeIndex = this.nodeChildrenArray.map(node => node.nodeAttributes.id).indexOf(focusNodeData.id);
         this.nodeChildrenArray[nodeIndex].makeSelectionVisible = false;
-        const selectedNodeIndex = this.selectedNodes.map(node => node.id).indexOf($event.id);
+        const selectedNodeIndex = this.selectedNodes.map(node => node.id).indexOf(focusNodeData.id);
         this.selectedNodes.splice(selectedNodeIndex, 1);
       }
     } else {
       for (const node of this.nodeChildrenArray) {
-        if (node.title === $event.id) {
+        if (node.nodeAttributes.id === focusNodeData.id) {
           node.makeSelectionVisible = true;
-        } else if (!this.arrayContainsNode(this.selectedNodes, node.title)) {
+        } else if (!this.arrayContainsNode(this.selectedNodes, node.nodeAttributes.id)) {
           node.makeSelectionVisible = false;
         }
       }
-      if (!this.arrayContainsNode(this.selectedNodes, $event.id)) {
+      if (!this.arrayContainsNode(this.selectedNodes, focusNodeData.id)) {
         this.clearSelectedNodes();
       }
     }
   }
 
-  updateAllNodes($event): void {
+  updateAllNodes(nodeId: string): void {
     if (this.selectedNodes.length > 0) {
       for (const selectedNode of this.selectedNodes) {
         const draggedSelectedNodeId = document.getElementById(selectedNode.id).id;
@@ -372,9 +376,9 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
         this.ngRedux.dispatch(this.actions.updateNodeCoordinates(nodeCoordinates));
       }
     } else {
-      const draggedSelectedNodeId = document.getElementById($event).id;
-      const draggedSelectedNodeLeft = document.getElementById($event).offsetLeft;
-      const draggedSelectedNodeTop = document.getElementById($event).offsetTop;
+      const draggedSelectedNodeId = document.getElementById(nodeId).id;
+      const draggedSelectedNodeLeft = document.getElementById(nodeId).offsetLeft;
+      const draggedSelectedNodeTop = document.getElementById(nodeId).offsetTop;
       const draggedSelectedNode = this.allNodeTemplates.find(node => node.id === draggedSelectedNodeId);
       const nodeCoordinates = {
         id: draggedSelectedNodeId,
@@ -399,12 +403,12 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
     return false;
   }
 
-  private enhanceDragSelection(id: string) {
-    this.newJsPlumbInstance.addToPosse(id, 'dragSelection');
-    if (!this.arrayContainsNode(this.selectedNodes, id)) {
-      this.selectedNodes.push(this.getNodeByID(this.allNodeTemplates, id));
+  private enhanceDragSelection(nodeId: string) {
+    this.newJsPlumbInstance.addToPosse(nodeId, 'dragSelection');
+    if (!this.arrayContainsNode(this.selectedNodes, nodeId)) {
+      this.selectedNodes.push(this.getNodeByID(this.allNodeTemplates, nodeId));
       for (const node of this.nodeChildrenArray) {
-        if (this.selectedNodes.find(selectedNode => selectedNode.id === node.title)) {
+        if (this.selectedNodes.find(selectedNode => selectedNode.id === node.nodeAttributes.id)) {
           node.makeSelectionVisible = true;
         }
       }
@@ -456,11 +460,11 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
     this.newJsPlumbInstance.repaintEverything();
   }
 
-  makeDraggable($event): void {
-    this.newJsPlumbInstance.draggable($event);
+  makeDraggable(nodeId: string): void {
+    this.newJsPlumbInstance.draggable(nodeId);
   }
 
-  trackTimeOfMouseDown($event): void {
+  trackTimeOfMouseDown($event: any): void {
     for (const node of this.nodeChildrenArray) {
       if (node.dragSource) {
         if (this.newJsPlumbInstance.isSource(node.dragSource)) {
@@ -473,7 +477,7 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
 
-  trackTimeOfMouseUp($event): void {
+  trackTimeOfMouseUp($event: any): void {
     this.endTime = new Date().getTime();
     this.testTimeDifference();
   }
@@ -488,10 +492,10 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
 
   ngAfterViewInit() {
     this.nodeChildrenArray = this.nodeComponentChildren.toArray();
-    this.nodeChildrenIdArray = this.nodeChildrenArray.map(node => node.title);
+    this.nodeChildrenIdArray = this.nodeChildrenArray.map(node => node.nodeAttributes.id);
     this.nodeComponentChildren.changes.subscribe(children => {
       this.nodeChildrenArray = children.toArray();
-      this.nodeChildrenIdArray = this.nodeChildrenArray.map(node => node.title);
+      this.nodeChildrenIdArray = this.nodeChildrenArray.map(node => node.nodeAttributes.id);
     });
   }
 

--- a/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.ts
@@ -10,8 +10,15 @@
  *     Thommy Zelenik - initial API and implementation
  */
 import {
-  Component, ElementRef, HostListener, OnDestroy, OnInit, NgZone,
-  QueryList, ViewChildren, AfterViewInit,
+  Component,
+  ElementRef,
+  HostListener,
+  OnDestroy,
+  OnInit,
+  NgZone,
+  QueryList,
+  ViewChildren,
+  AfterViewInit
 } from '@angular/core';
 import {JsPlumbService} from '../jsPlumbService';
 import {JsonService} from '../jsonService/json.service';
@@ -85,10 +92,12 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
           const nodeId = this.nodeChildrenIdArray.indexOf(this.allNodeTemplates[i].id);
           this.nodeChildrenArray[nodeId].name = node.name;
           this.nodeChildrenArray[nodeId].flash();
+          this.allNodeTemplates[i].name = node.name;
         }
       }
     }
   }
+
 
   updateRelationships(currentRelationships: Array<TRelationshipTemplate>): void {
     this.allRelationshipTemplates = currentRelationships;
@@ -208,7 +217,7 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   showSelectionRange($event) {
-    console.log('mousedown');
+    // mousedown
     this.ngRedux.dispatch(this.actions.sendPaletteOpened(false));
     this.hideSidebar();
     this.clearSelectedNodes();
@@ -249,7 +258,7 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   selectElements($event) {
-    console.log('mouseUp');
+    // mouseUp
     for (const node of this.allNodeTemplates) {
       const aElem = document.getElementById('selection');
       const bElem = document.getElementById(node.id);
@@ -347,7 +356,6 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   updateAllNodes($event): void {
-    const draggedNode = this.allNodeTemplates.find(node => node.id === $event);
     if (this.selectedNodes.length > 0) {
       for (const selectedNode of this.selectedNodes) {
         const draggedSelectedNodeId = document.getElementById(selectedNode.id).id;

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.html
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.html
@@ -1,7 +1,8 @@
 <div class="container rounded"
-     style="padding: 3px; position: absolute; user-select: none" [style.top]="otherAttributes.y + 'px'"
-     [style.left]="otherAttributes.x + 'px'"
-     id={{title}} [style.borderColor]="nodeColor" [style.backgroundColor]="nodeColor"
+     style="padding: 3px; position: absolute; user-select: none"
+     [style.top]="nodeAttributes.otherAttributes.y + 'px'"
+     [style.left]="nodeAttributes.otherAttributes.x + 'px'"
+     id={{nodeAttributes.id}} [style.borderColor]="nodeAttributes.color" [style.backgroundColor]="nodeAttributes.color"
      (mousedown)="mouseDownHandler($event)"
      (mouseup)="mouseUpHandler($event)">
   <div class="row rounded"
@@ -9,23 +10,23 @@
        [class.unselected]="!makeSelectionVisible"
        (click)="openSidebar($event);">
     <div class="col-sm-3">
-      <img *ngIf="!nodeImageUrl" src="https://api.adorable.io/avatars/50/{{title}}"
+      <img *ngIf="!nodeAttributes.imageUrl" src="https://api.adorable.io/avatars/50/{{nodeAttributes.id}}"
            style="border-radius: 10%; margin-top: 1px">
-      <img *ngIf="nodeImageUrl" src="{{nodeImageUrl}}">
+      <img *ngIf="nodeAttributes.imageUrl" src="{{nodeAttributes.imageUrl}}">
     </div>
     <div id="specifierDiv" class="col-sm-9">
       <table class="table table-active table-border--grey table-sm header-table">
         <tr [class.flashit]="setFlash">
           <td class="td-key">name:</td>
-          <td class="td-value">{{name}}</td>
+          <td class="td-value">{{nodeAttributes.name}}</td>
         </tr>
         <tr *ngIf="navbarButtonsState.buttonsState.idsButton">
           <td class="td-key">id:</td>
-          <td class="td-value" style="color: crimson">{{title}}</td>
+          <td class="td-value" style="color: crimson">{{nodeAttributes.id}}</td>
         </tr>
         <tr *ngIf="navbarButtonsState.buttonsState.typesButton">
           <td class="td-key">type:</td>
-          <td class="btn-link td-value">{{title}}</td>
+          <td class="btn-link td-value">{{nodeAttributes.id}}</td>
         </tr>
       </table>
     </div>
@@ -118,67 +119,3 @@
     </accordion-group>
   </accordion>
 </div>
-<!--
-<div class="old-container-style" [style.top]="top" [style.left]="left"
-     id={{title}} [style.borderColor]="nodeColor" [style.backgroundColor]="nodeColor"
-     [class.selected]="makeSelectionVisible"
-     (mousedown)="trackTimeOfMouseDown()"
-     (mouseup)="trackTimeOfMouseUp()"
-     (click)="showConnectorEndpoint($event)">
-  <div class="old-row-style">
-    <div>
-    </div>
-    <div id="specifierDiv">
-      <p class="old-name">{{title}}</p>
-      <p class="old-id" *ngIf="idsVisible">{{title}}</p>
-      <a href="#" class="old-type" *ngIf="typesVisible">{{title}}</a>
-    </div>
-  </div>
-    &lt;!&ndash; PROPERTIES &ndash;&gt;
-    <div class="old-properties-style"
-      *ngIf="propertiesVisible">
-      <div class="old-properties-header-style">
-        Properties
-        <i class="pull-sm-0 float-sm-right fa"></i>
-      </div>
-    </div>
-    &lt;!&ndash; DEPLOYMENT ARTIFACTS &ndash;&gt;
-    <div class="old-deployment-style"
-      #deploymentartifactsgroup
-      *ngIf="deploymentArtifactsVisible">
-      <div class="old-deployment-header-style">
-        Deployment Artifacts
-        <i class="pull-sm-0 float-sm-right fa icon-styling"></i>
-      </div>
-    </div>
-    &lt;!&ndash; REQUIREMENTS & CAPABILITIES &ndash;&gt;
-    <div class="old-requirements-style"
-      #requirementscapabilitiesgroup
-      *ngIf="requirementsCapabilitiesVisible">
-      <div class="old-requirements-header-style">
-        Requirements - Capabilities
-        <i class="pull-sm-0 float-sm-right fa icon-styling"></i>
-      </div>
-    </div>
-    &lt;!&ndash; POLICIES &ndash;&gt;
-    <div class="old-policies-style"
-      #policiesgroup
-      *ngIf="policiesVisible">
-      <div class="old-policies-header-style">
-        Policies
-        <i class="pull-sm-0 float-sm-right fa icon-styling">
-        </i>
-      </div>
-    </div>
-    &lt;!&ndash; TARGET LOCATIONS &ndash;&gt;
-    <div class="old-target-style"
-      #targetlocationsgroup
-      *ngIf="targetLocationsVisible">
-      <div>
-        Target Locations
-        <i class="pull-sm-0 float-sm-right fa icon-styling">
-        </i>
-      </div>
-    </div>
-  </div>
--->

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.html
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.html
@@ -1,8 +1,9 @@
 <div class="container rounded"
-     style="padding: 3px; position: absolute; user-select: none" [style.top]="top" [style.left]="left"
+     style="padding: 3px; position: absolute; user-select: none" [style.top]="otherAttributes.y + 'px'"
+     [style.left]="otherAttributes.x + 'px'"
      id={{title}} [style.borderColor]="nodeColor" [style.backgroundColor]="nodeColor"
-     (mousedown)="trackTimeOfMouseDown($event)"
-     (mouseup)="trackTimeOfMouseUp($event)">
+     (mousedown)="mouseDownHandler($event)"
+     (mouseup)="mouseUpHandler($event)">
   <div class="row rounded"
        [class.selected]="makeSelectionVisible"
        [class.unselected]="!makeSelectionVisible"
@@ -14,7 +15,7 @@
     </div>
     <div id="specifierDiv" class="col-sm-9">
       <table class="table table-active table-border--grey table-sm header-table">
-        <tr [class.flashit]="ngOnChanges()">
+        <tr [class.flashit]="setFlash">
           <td class="td-key">name:</td>
           <td class="td-value">{{name}}</td>
         </tr>

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.ts
@@ -39,16 +39,12 @@ export class NodeComponent implements OnInit, AfterViewInit {
   longpress = false;
   makeSelectionVisible = false;
   setFlash = false;
+  @Input() nodeAttributes: any;
   @Input() needsToBeFlashed: boolean;
-  @Input() title: string;
-  @Input() name: string;
-  @Input() otherAttributes: any;
-  @Output() sendId: EventEmitter<string>;
-  @Output() askForRepaint: EventEmitter<string>;
-  @Input() nodeColor: string;
-  @Input() nodeImageUrl: string;
   @Input() dragSource: string;
   @Input() navbarButtonsState: ButtonsStateModel;
+  @Output() sendId: EventEmitter<string>;
+  @Output() askForRepaint: EventEmitter<string>;
   @Output() setDragSource: EventEmitter<any>;
   @Output() closedEndpoint: EventEmitter<string>;
   @Output() checkFocusNode: EventEmitter<any>;
@@ -75,7 +71,7 @@ export class NodeComponent implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    this.sendId.emit(this.title);
+    this.sendId.emit(this.nodeAttributes.id);
   }
 
   private repaint($event) {
@@ -90,25 +86,25 @@ export class NodeComponent implements OnInit, AfterViewInit {
   mouseDownHandler($event): void {
     this.startTime = new Date().getTime();
     const focusNodeData = {
-      id: this.title,
+      id: this.nodeAttributes.id,
       ctrlKey: $event.ctrlKey
     };
     this.checkFocusNode.emit(focusNodeData);
     if ($event.srcElement.parentElement.className !== 'accordion-toggle') {
       this.previousPosition = {
-        left: document.getElementById(this.title).offsetLeft,
-        top: document.getElementById(this.title).offsetTop
+        left: document.getElementById(this.nodeAttributes.id).offsetLeft,
+        top: document.getElementById(this.nodeAttributes.id).offsetTop
       };
       this.zone.runOutsideAngular(() => {
-        document.getElementById(this.title).addEventListener('mousemove', this.bindMouseMove);
+        document.getElementById(this.nodeAttributes.id).addEventListener('mousemove', this.bindMouseMove);
       });
     }
   }
 
   mouseMove($event): void {
     this.currentPosition = {
-      left: document.getElementById(this.title).offsetLeft,
-      top: document.getElementById(this.title).offsetTop
+      left: document.getElementById(this.nodeAttributes.id).offsetLeft,
+      top: document.getElementById(this.nodeAttributes.id).offsetTop
     };
     if (this.previousPosition.left !== this.currentPosition.left ||
         this.previousPosition.top !== this.currentPosition.top) {
@@ -119,13 +115,13 @@ export class NodeComponent implements OnInit, AfterViewInit {
 
   mouseUpHandler($event): void {
     // mouseup
-    document.getElementById(this.title).removeEventListener('mousemove', this.bindMouseMove);
+    document.getElementById(this.nodeAttributes.id).removeEventListener('mousemove', this.bindMouseMove);
     this.endTime = new Date().getTime();
     this.testTimeDifference($event);
     if (this.previousPosition !== undefined && this.currentPosition !== undefined) {
       if (this.previousPosition.left !== this.currentPosition.left ||
         this.previousPosition.top !== this.currentPosition.top) {
-        this.updateAllNodes.emit(this.title);
+        this.updateAllNodes.emit(this.nodeAttributes.id);
       }
     }
   }
@@ -138,7 +134,7 @@ export class NodeComponent implements OnInit, AfterViewInit {
   private testTimeDifference($event): void {
     if ((this.endTime - this.startTime) < 250) {
       if (!$event.ctrlKey) {
-        this.closedEndpoint.emit(this.title);
+        this.closedEndpoint.emit(this.nodeAttributes.id);
       }
       this.longpress = false;
     } else if (this.endTime - this.startTime >= 300) {
@@ -149,7 +145,7 @@ export class NodeComponent implements OnInit, AfterViewInit {
   makeSource($event): void {
     const dragSourceInfo = {
       dragSource: this.dragSource,
-      nodeId: this.title
+      nodeId: this.nodeAttributes.id
     };
     this.setDragSource.emit(dragSourceInfo);
   }
@@ -170,8 +166,8 @@ export class NodeComponent implements OnInit, AfterViewInit {
       this.$ngRedux.dispatch(this.actions.openSidebar({
         sidebarContents: {
           sidebarVisible: true,
-          nodeId: this.title,
-          nameTextFieldValue: this.name
+          nodeId: this.nodeAttributes.id,
+          nameTextFieldValue: this.nodeAttributes.name
         }
       }));
     }

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.ts
@@ -118,7 +118,7 @@ export class NodeComponent implements OnInit, AfterViewInit {
 
 
   mouseUpHandler($event): void {
-    console.log('mouseup');
+    // mouseup
     document.getElementById(this.title).removeEventListener('mousemove', this.bindMouseMove);
     this.endTime = new Date().getTime();
     this.testTimeDifference($event);
@@ -132,6 +132,7 @@ export class NodeComponent implements OnInit, AfterViewInit {
 
   flash(): void {
     this.setFlash = true;
+    setTimeout(() => this.setFlash = false, 1000);
   }
 
   private testTimeDifference($event): void {

--- a/org.eclipse.winery.topologymodeler.ui/src/app/redux/actions/winery.actions.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/redux/actions/winery.actions.ts
@@ -36,6 +36,10 @@ export interface SaveNodeTemplateAction extends Action {
   nodeTemplate: TNodeTemplate;
 }
 
+export interface UpdateNodeCoordinatesAction extends Action {
+  otherAttributes: any;
+}
+
 export interface SaveRelationshipAction extends Action {
   relationshipTemplate: TRelationshipTemplate;
 }
@@ -53,6 +57,7 @@ export class WineryActions {
     static DELETE_NODE_TEMPLATE = 'DELETE_NODE_TEMPLATE';
     static CHANGE_NODE_NAME = 'CHANGE_NODE_NAME';
     static OPEN_SIDEBAR = 'OPEN_SIDEBAR';
+    static UPDATE_NODE_COORDINATES = 'UPDATE_NODE_COORDINATES';
 
     sendPaletteOpened: ActionCreator<SendPaletteOpenedAction> =
       ((paletteOpened) => ({
@@ -83,5 +88,10 @@ export class WineryActions {
       ((deletedNodeId) => ({
         type: WineryActions.DELETE_NODE_TEMPLATE,
         nodeTemplateId: deletedNodeId
+      }));
+    updateNodeCoordinates: ActionCreator<UpdateNodeCoordinatesAction> =
+      ((currentNodeCoordinates) => ({
+        type: WineryActions.UPDATE_NODE_COORDINATES,
+        otherAttributes: currentNodeCoordinates
       }));
 }

--- a/org.eclipse.winery.topologymodeler.ui/src/app/redux/reducers/winery.reducer.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/redux/reducers/winery.reducer.ts
@@ -64,7 +64,7 @@ export const WineryReducer =
           currentJsonTopology: {
             ...lastState.currentJsonTopology,
             nodeTemplates: lastState.currentJsonTopology.nodeTemplates.map(nodeTemplate => nodeTemplate.name === nodeNames.oldNodeName ?
-              new TNodeTemplate(
+              nodeTemplate = new TNodeTemplate(
                 lastState.currentJsonTopology.nodeTemplates[index].properties,
                 // id
                 lastState.currentJsonTopology.nodeTemplates[index].id,

--- a/org.eclipse.winery.topologymodeler.ui/src/app/redux/reducers/winery.reducer.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/redux/reducers/winery.reducer.ts
@@ -59,12 +59,38 @@ export const WineryReducer =
       case WineryActions.CHANGE_NODE_NAME:
         const nodeNames: any = (<SidebarNodeNamechange>action).nodeNames;
         const index = lastState.currentJsonTopology.nodeTemplates.map(el => el.name).indexOf(nodeNames.oldNodeName);
-        return {
+        console.log(index);
+        console.log(nodeNames);
+        console.log({
           ...lastState,
           currentJsonTopology: {
             ...lastState.currentJsonTopology,
             nodeTemplates: lastState.currentJsonTopology.nodeTemplates.map(nodeTemplate => nodeTemplate.name === nodeNames.oldNodeName ?
               nodeTemplate = new TNodeTemplate(
+                lastState.currentJsonTopology.nodeTemplates[index].properties,
+                // id
+                lastState.currentJsonTopology.nodeTemplates[index].id,
+                // type
+                lastState.currentJsonTopology.nodeTemplates[index].type,
+                // name
+                nodeNames.newNodeName,
+                lastState.currentJsonTopology.nodeTemplates[index].minInstances,
+                lastState.currentJsonTopology.nodeTemplates[index].maxInstances,
+                lastState.currentJsonTopology.nodeTemplates[index].color,
+                lastState.currentJsonTopology.nodeTemplates[index].imageUrl,
+                lastState.currentJsonTopology.nodeTemplates[index].any,
+                lastState.currentJsonTopology.nodeTemplates[index].documentation,
+                lastState.currentJsonTopology.nodeTemplates[index].otherAttributes
+              ) : nodeTemplate
+            )
+          }
+        });
+        return {
+          ...lastState,
+          currentJsonTopology: {
+            ...lastState.currentJsonTopology,
+            nodeTemplates: lastState.currentJsonTopology.nodeTemplates.map(nodeTemplate => nodeTemplate.name === nodeNames.oldNodeName ?
+              new TNodeTemplate(
                 lastState.currentJsonTopology.nodeTemplates[index].properties,
                 // id
                 lastState.currentJsonTopology.nodeTemplates[index].id,

--- a/org.eclipse.winery.topologymodeler.ui/src/app/redux/reducers/winery.reducer.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/redux/reducers/winery.reducer.ts
@@ -11,13 +11,13 @@
  */
 import { Action } from 'redux';
 import {
-  WineryActions,
+  DeleteNodeAction,
   SaveNodeTemplateAction,
   SaveRelationshipAction,
   SendPaletteOpenedAction,
-  DeleteNodeAction,
   SidebarNodeNamechange,
-  SidebarStateAction,
+  SidebarStateAction, UpdateNodeCoordinatesAction,
+  WineryActions
 } from '../actions/winery.actions';
 import { TNodeTemplate, TRelationshipTemplate, TTopologyTemplate } from 'app/ttopology-template';
 
@@ -59,33 +59,6 @@ export const WineryReducer =
       case WineryActions.CHANGE_NODE_NAME:
         const nodeNames: any = (<SidebarNodeNamechange>action).nodeNames;
         const index = lastState.currentJsonTopology.nodeTemplates.map(el => el.name).indexOf(nodeNames.oldNodeName);
-        console.log(index);
-        console.log(nodeNames);
-        console.log({
-          ...lastState,
-          currentJsonTopology: {
-            ...lastState.currentJsonTopology,
-            nodeTemplates: lastState.currentJsonTopology.nodeTemplates.map(nodeTemplate => nodeTemplate.name === nodeNames.oldNodeName ?
-              nodeTemplate = new TNodeTemplate(
-                lastState.currentJsonTopology.nodeTemplates[index].properties,
-                // id
-                lastState.currentJsonTopology.nodeTemplates[index].id,
-                // type
-                lastState.currentJsonTopology.nodeTemplates[index].type,
-                // name
-                nodeNames.newNodeName,
-                lastState.currentJsonTopology.nodeTemplates[index].minInstances,
-                lastState.currentJsonTopology.nodeTemplates[index].maxInstances,
-                lastState.currentJsonTopology.nodeTemplates[index].color,
-                lastState.currentJsonTopology.nodeTemplates[index].imageUrl,
-                lastState.currentJsonTopology.nodeTemplates[index].any,
-                lastState.currentJsonTopology.nodeTemplates[index].documentation,
-                lastState.currentJsonTopology.nodeTemplates[index].otherAttributes
-              ) : nodeTemplate
-            )
-          }
-        });
-
         return {
           ...lastState,
           currentJsonTopology: {
@@ -110,9 +83,36 @@ export const WineryReducer =
             )
           }
         };
-      case
-      WineryActions.SAVE_NODE_TEMPLATE
-      :
+      case WineryActions.UPDATE_NODE_COORDINATES:
+        const currentNodeCoordinates: any = (<UpdateNodeCoordinatesAction>action).otherAttributes;
+        const otherAttributes = {
+          x: currentNodeCoordinates.x,
+          y: currentNodeCoordinates.y
+        };
+        const nodeId = currentNodeCoordinates.id;
+        const nodeIndex = lastState.currentJsonTopology.nodeTemplates.map(nodeTemplate => nodeTemplate.id).indexOf(nodeId);
+        return {
+          ...lastState,
+          currentJsonTopology: {
+            ...lastState.currentJsonTopology,
+            nodeTemplates: lastState.currentJsonTopology.nodeTemplates.map(nodeTemplate => nodeTemplate.id === nodeId ?
+              new TNodeTemplate(
+                lastState.currentJsonTopology.nodeTemplates[nodeIndex].properties,
+                lastState.currentJsonTopology.nodeTemplates[nodeIndex].id,
+                lastState.currentJsonTopology.nodeTemplates[nodeIndex].type,
+                lastState.currentJsonTopology.nodeTemplates[nodeIndex].name,
+                lastState.currentJsonTopology.nodeTemplates[nodeIndex].minInstances,
+                lastState.currentJsonTopology.nodeTemplates[nodeIndex].maxInstances,
+                lastState.currentJsonTopology.nodeTemplates[nodeIndex].color,
+                lastState.currentJsonTopology.nodeTemplates[nodeIndex].imageUrl,
+                lastState.currentJsonTopology.nodeTemplates[nodeIndex].any,
+                lastState.currentJsonTopology.nodeTemplates[nodeIndex].documentation,
+                otherAttributes
+              ) : nodeTemplate
+            )
+          }
+        };
+      case WineryActions.SAVE_NODE_TEMPLATE :
         const newNode: TNodeTemplate = (<SaveNodeTemplateAction>action).nodeTemplate;
         return {
           ...lastState,
@@ -121,9 +121,7 @@ export const WineryReducer =
             nodeTemplates: [...lastState.currentJsonTopology.nodeTemplates, newNode]
           }
         };
-      case
-      WineryActions.SAVE_RELATIONSHIP
-      :
+      case WineryActions.SAVE_RELATIONSHIP :
         const newRelationship: TRelationshipTemplate = (<SaveRelationshipAction>action).relationshipTemplate;
         return {
           ...lastState,
@@ -140,11 +138,10 @@ export const WineryReducer =
             nodeTemplates: lastState.currentJsonTopology.nodeTemplates.filter(nodeTemplate => nodeTemplate.id !== deletedNodeId),
             relationshipTemplates: lastState.currentJsonTopology.relationshipTemplates.filter(
               relationshipTemplate => relationshipTemplate.sourceElement !== deletedNodeId &&
-                        relationshipTemplate.targetElement !== deletedNodeId)
+              relationshipTemplate.targetElement !== deletedNodeId)
           }
         };
       default:
         return lastState;
     }
-  }
-;
+  };

--- a/org.eclipse.winery.topologymodeler.ui/src/app/sidebar/sidebar.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/sidebar/sidebar.component.ts
@@ -61,7 +61,7 @@ export class SidebarComponent implements OnInit {
         }
       );
     this.nodeTemplateSubscription = this.$ngRedux.select(state => state.wineryState.currentJsonTopology.nodeTemplates)
-      .subscribe(nodeTemplates => {
+      .subscribe((nodeTemplates) => {
 
       });
     // apply changes to the node name <input> field with a debounceTime of 300ms

--- a/org.eclipse.winery.topologymodeler.ui/src/app/winery.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/winery.component.ts
@@ -265,8 +265,8 @@ export class WineryComponent implements OnInit {
         )
       );
     }
-    for (let i = 0; i < this.nodeTemplates.length; i++) {
-      this.ngRedux.dispatch(this.actions.saveNodeTemplate(this.nodeTemplates[i]));
+    for (const nodeTemplate of this.nodeTemplates) {
+      this.ngRedux.dispatch(this.actions.saveNodeTemplate(nodeTemplate));
     }
     for (const relationship of this.testJson.relationshipTemplates) {
       this.relationshipTemplates.push(
@@ -278,9 +278,8 @@ export class WineryComponent implements OnInit {
         )
       );
     }
-    for (let i = 0; i < this.relationshipTemplates.length; i++) {
-      this.ngRedux.dispatch(this.actions.saveRelationship(this.relationshipTemplates[i]));
-      console.log(this.relationshipTemplates[i]);
+    for (const relationshipTemplate of this.relationshipTemplates) {
+      this.ngRedux.dispatch(this.actions.saveRelationship(relationshipTemplate));
     }
   }
 }


### PR DESCRIPTION
- x and y coordinates are now pushed to the store after each node dragging
- Fixed the sidebar issue: When editing the node name via the sidebar the nodes are not jumping to 
   their old position back because the x and y coordinates are now up-to-date in the store
- Each relationship is repainted after adding or deleting one
- Sidebar closes now when clicking into the canvas and when zero nodes are available
- Improved the Drag Drop Functionality, fixed bug so that the drag-Source container toggles now after 
  each short mouseclick
- Some Refactorings

- Contributor: Thommy Zelenik, @zelenikty
- Supervisor: Oliver Kopp, @koppor
