### PR TITLE
Fix2

### DIFF
--- a/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.html
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.html
@@ -17,6 +17,7 @@
     </div>
   </div>
 
+  <div #nodes>
   <winery-node *ngFor="let node of allNodeTemplates"
                [nodeAttributes]="{
                 properties: node.properties,
@@ -31,6 +32,7 @@
                 any: node.any,
                 otherAttributes: node.otherAttributes
                }"
+               [makeNewNodeSelectionVisible]="makeNewNodeSelectionVisible"
                [relationshipTemplates]="allRelationshipTemplates"
                [needsToBeFlashed]="needsToBeFlashed"
                (sendId)="makeDraggable($event)"
@@ -44,4 +46,5 @@
                (checkFocusNode)="checkFocusNode($event)"
                (updateAllNodes)="updateAllNodes($event)">
   </winery-node>
+  </div>
 </div>

--- a/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.html
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.html
@@ -34,7 +34,7 @@
                 otherAttributes: node.otherAttributes
                }"
                [makeNewNodeSelectionVisible]="makeNewNodeSelectionVisible"
-               [relationshipTemplates]="allRelationshipTemplates"
+               [allRelationshipTypesColors]="allRelationshipTypesColors"
                [needsToBeFlashed]="needsToBeFlashed"
                (sendId)="makeDraggable($event)"
                [navbarButtonsState]="navbarButtonsState"

--- a/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.html
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.html
@@ -12,7 +12,8 @@
          [style.left.px]="pageX"
          [style.top.px]="pageY"
          [style.width.px]="selectionWidth"
-         [style.height.px]="selectionHeight">
+         [style.height.px]="selectionHeight"
+         #selection>
       <span></span>
     </div>
   </div>

--- a/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.html
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.html
@@ -45,7 +45,8 @@
                (sendCurrentType)="sendCurrentType($event)"
                [dragSource]="node.id + 'Endpoint'"
                (checkFocusNode)="checkFocusNode($event)"
-               (updateAllNodes)="updateAllNodes($event)">
+               (updateAllNodes)="updateAllNodes($event)"
+               (unmarkConnections)="unmarkConnections($event)">
   </winery-node>
   </div>
 </div>

--- a/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.ts
@@ -42,6 +42,7 @@ import { Hotkey, HotkeysService } from 'angular2-hotkeys';
 export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
   @ViewChildren(NodeComponent) nodeComponentChildren: QueryList<NodeComponent>;
   @ViewChild('nodes') child: ElementRef;
+  @ViewChild('selection') selection: ElementRef;
   allNodeTemplates: Array<TNodeTemplate> = [];
   allRelationshipTemplates: Array<TRelationshipTemplate> = [];
   navbarButtonsState: ButtonsStateModel;
@@ -110,7 +111,6 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
     this.newJsPlumbInstance = this.jsPlumbService.getJsPlumbInstance();
     this.newJsPlumbInstance.setContainer('container');
     console.log(this.newJsPlumbInstance);
-    console.log(this._eref.nativeElement.children);
   }
 
   updateNodes(currentNodes: Array<TNodeTemplate>): void {
@@ -378,12 +378,12 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   selectElements($event: any) {
-    const aElem = document.getElementById('selection');
-    for (const node of this.allNodeTemplates) {
-      const bElem = document.getElementById(node.id);
+    const aElem = this.selection.nativeElement;
+    for (const node of this.child.nativeElement.children) {
+      const bElem = node.firstChild;
       const result = this.isObjectInSelection(aElem, bElem);
       if (result === true) {
-        this.enhanceDragSelection(node.id);
+        this.enhanceDragSelection(node.firstChild.id);
       }
     }
     this.unbindMouseMove();
@@ -420,12 +420,11 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
 
   private isObjectInSelection(selectionArea, object): boolean {
     const selectionRect = selectionArea.getBoundingClientRect();
-    const objectRect = object.getBoundingClientRect();
     return (
-      ((selectionRect.top + selectionRect.height) > (objectRect.top + objectRect.height)) &&
-      (selectionRect.top < (objectRect.top)) &&
-      ((selectionRect.left + selectionArea.getBoundingClientRect().width) > (objectRect.left + objectRect.width)) &&
-      (selectionRect.left < (objectRect.left))
+      ((selectionRect.top + selectionRect.height) > (object.offsetTop + object.offsetHeight)) &&
+      (selectionRect.top < (object.offsetTop)) &&
+      ((selectionRect.left + selectionArea.getBoundingClientRect().width) > (object.offsetLeft + object.offsetWidth)) &&
+      (selectionRect.left < (object.offsetLeft))
     );
   }
 

--- a/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.ts
@@ -18,7 +18,8 @@ import {
   NgZone,
   QueryList,
   ViewChildren,
-  AfterViewInit
+  AfterViewInit,
+  Renderer2, ViewChild
 } from '@angular/core';
 import { JsPlumbService } from '../jsPlumbService';
 import { JsonService } from '../jsonService/json.service';
@@ -40,6 +41,7 @@ import { Hotkey, HotkeysService } from 'angular2-hotkeys';
 })
 export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
   @ViewChildren(NodeComponent) nodeComponentChildren: QueryList<NodeComponent>;
+  @ViewChild('nodes') child: ElementRef;
   allNodeTemplates: Array<TNodeTemplate> = [];
   allRelationshipTemplates: Array<TRelationshipTemplate> = [];
   navbarButtonsState: ButtonsStateModel;
@@ -62,26 +64,42 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
   nodeTemplatesSubscription;
   relationshipTemplatesSubscription;
   navBarButtonsStateSubscription;
+  paletteOpenedSubscription;
   dragSourceActive = false;
   gridWidth = 100;
   gridHeight = 100;
   currentType: string;
   nodeChildrenIdArray: Array<string>;
   nodeChildrenArray: Array<NodeComponent>;
+  jsPlumbConnections: Array<any> = [];
+  jsPlumbBindConnection = false;
+  unbindMouseMove: Function;
+  unbindMouseUp: Function;
+  unbindNewNodeMouseMove: Function;
+  unbindNewNodeMouseUp: Function;
+  newNode: TNodeTemplate;
+  currentPaletteOpenedState: boolean;
+  makeNewNodeSelectionVisible: any;
+  newNodeData: any;
 
-  constructor(private jsPlumbService: JsPlumbService, private jsonService: JsonService, private _eref: ElementRef,
+  constructor(private jsPlumbService: JsPlumbService,
+              private jsonService: JsonService,
+              private _eref: ElementRef,
               private _layoutDirective: LayoutDirective,
               private ngRedux: NgRedux<IWineryState>,
               private actions: WineryActions,
               private topologyRendererActions: TopologyRendererActions,
               private zone: NgZone,
-              private hotkeysService: HotkeysService) {
+              private hotkeysService: HotkeysService,
+              private renderer: Renderer2) {
     this.nodeTemplatesSubscription = this.ngRedux.select(state => state.wineryState.currentJsonTopology.nodeTemplates)
       .subscribe(currentNodes => this.updateNodes(currentNodes));
     this.relationshipTemplatesSubscription = this.ngRedux.select(state => state.wineryState.currentJsonTopology.relationshipTemplates)
       .subscribe(currentRelationships => this.updateRelationships(currentRelationships));
     this.navBarButtonsStateSubscription = ngRedux.select(state => state.topologyRendererState)
       .subscribe(currentButtonsState => this.setButtonsState(currentButtonsState));
+    this.paletteOpenedSubscription = this.ngRedux.select(state => state.wineryState.currentPaletteOpenedState)
+      .subscribe(currentPaletteOpened => this.setPaletteState(currentPaletteOpened));
     this.hotkeysService.add(new Hotkey('ctrl+a', (event: KeyboardEvent): boolean => {
       event.stopPropagation();
       for (const node of this.allNodeTemplates) {
@@ -89,40 +107,102 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
       }
       return false; // Prevent bubbling
     }));
+    this.newJsPlumbInstance = this.jsPlumbService.getJsPlumbInstance();
+    this.newJsPlumbInstance.setContainer('container');
+    console.log(this.newJsPlumbInstance);
+    console.log(this._eref.nativeElement.children);
   }
 
   updateNodes(currentNodes: Array<TNodeTemplate>): void {
     if (currentNodes.length !== this.allNodeTemplates.length) {
+      if (currentNodes.length > this.allNodeTemplates.length) {
+        this.newNode = currentNodes[currentNodes.length - 1];
+        this.unbindConnection();
+        this.clearSelectedNodes();
+        this.repaintConnections();
+        if (this.currentPaletteOpenedState) {
+          this.addNewNodeToDragSelection(this.newNode.id, currentNodes);
+          this.makeNewNodeSelectionVisible = {
+            id: this.newNode.id,
+          };
+          this.zone.runOutsideAngular(() => {
+            this.unbindNewNodeMouseMove = this.renderer.listen(this._eref.nativeElement, 'mousemove',
+              (event) => this.moveNewNode(event));
+            this.unbindNewNodeMouseUp = this.renderer.listen(this._eref.nativeElement, 'mouseup',
+              ($event) => this.positionNewNode($event));
+          });
+        }
+      }
       this.allNodeTemplates = currentNodes;
       this.allNodesIds = this.allNodeTemplates.map(node => node.id);
     } else {
       for (let i = 0; i < this.allNodeTemplates.length; i++) {
         const node = currentNodes.find(el => el.id === this.allNodeTemplates[i].id);
-        if (this.allNodeTemplates[i].name !== node.name) {
-          const nodeId = this.nodeChildrenIdArray.indexOf(this.allNodeTemplates[i].id);
-          this.nodeChildrenArray[nodeId].nodeAttributes.name = node.name;
-          this.nodeChildrenArray[nodeId].flash();
-          this.allNodeTemplates[i].name = node.name;
-          this.repaintJsPlumb();
+        if (node) {
+          if (this.allNodeTemplates[i].name !== node.name) {
+            const nodeId = this.nodeChildrenIdArray.indexOf(this.allNodeTemplates[i].id);
+            this.nodeChildrenArray[nodeId].nodeAttributes.name = node.name;
+            this.nodeChildrenArray[nodeId].flash();
+            this.allNodeTemplates[i].name = node.name;
+          }
         }
       }
     }
-    if (this.allRelationshipTemplates.length > 0) {
-      for (const relationship of this.allRelationshipTemplates) {
-        setTimeout(() => this.displayRelationships(relationship), 1);
-      }
+  }
+
+
+  addNewNodeToDragSelection(nodeId: string, currentNodes: Array<TNodeTemplate>): void {
+    if (!this.arrayContainsNode(this.selectedNodes, nodeId)) {
+      this.selectedNodes.push(this.getNodeByID(currentNodes, nodeId));
+      this.newJsPlumbInstance.addToPosse(nodeId, 'dragSelection');
     }
   }
 
+  moveNewNode(event): void {
+    event.preventDefault();
+    const indexOfNewNode = this.allNodeTemplates.map(node => node.id).indexOf(this.newNode.id);
+    this.newNodeData = {
+      id: this.newNode.id,
+      x: event.clientX - 100,
+      y: event.clientY - 30
+    };
+    this.allNodeTemplates[indexOfNewNode].otherAttributes.x = this.newNodeData.x;
+    this.allNodeTemplates[indexOfNewNode].otherAttributes.y = this.newNodeData.y;
+  }
+
+  positionNewNode($event): void {
+    this.updateAllNodes('Position new Node');
+    this.unbindNewNodeMouseMove();
+    this.unbindNewNodeMouseUp();
+  }
+
+  setPaletteState(currentPaletteOpened: boolean): void {
+    this.currentPaletteOpenedState = currentPaletteOpened;
+  }
+
+  repaintConnections(): void {
+    if (this.newJsPlumbInstance) {
+      this.newJsPlumbInstance.deleteEveryConnection();
+      for (const relationship of this.allRelationshipTemplates) {
+        setTimeout(() => this.paintRelationship(relationship), 1);
+      }
+      // console.log(this.newJsPlumbInstance.getAllConnections());
+      // console.log(this.allRelationshipTemplates);
+      this.repaintJsPlumb();
+    }
+  }
 
   updateRelationships(currentRelationships: Array<TRelationshipTemplate>): void {
     this.allRelationshipTemplates = currentRelationships;
-    if (this.allRelationshipTemplates.length > 0) {
-      for (const relationship of this.allRelationshipTemplates) {
-        setTimeout(() => this.displayRelationships(relationship), 1);
+    setTimeout(() => {
+      if (this.allRelationshipTemplates.length > 0) {
+        for (const relationship of this.allRelationshipTemplates) {
+          this.manageRelationships(relationship);
+        }
       }
-    }
+    }, 1);
   }
+
 
   setButtonsState(currentButtonsState: ButtonsStateModel): void {
     this.navbarButtonsState = currentButtonsState;
@@ -150,44 +230,56 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
     }
   }
 
-  displayRelationships(newRelationship: TRelationshipTemplate): void {
-    this.newJsPlumbInstance.connect({
-      source: newRelationship.sourceElement,
-      target: newRelationship.targetElement,
-      overlays: [['Arrow', {width: 15, length: 15, location: 1, id: 'arrow', direction: 1}],
-        ['Label', {
-          label: newRelationship.type,
-          id: 'label',
-          labelStyle: {
-            font: '11px Roboto, sans-serif',
-            color: '#FAFAFA',
-            fill: '#303030',
-            borderStyle: '#424242',
-            borderWidth: 1,
-            padding: '3px'
-          }
-        }]
-      ],
-    });
-    this.resetDragSource('reset drag source');
+  paintRelationship(newRelationship: TRelationshipTemplate) {
+    const allJsPlumbRelationships = this.newJsPlumbInstance.getAllConnections();
+    if (!allJsPlumbRelationships.map(rel => rel.id).includes(newRelationship.id)) {
+      const conn = this.newJsPlumbInstance.connect({
+        source: newRelationship.sourceElement,
+        target: newRelationship.targetElement,
+        overlays: [['Arrow', {width: 15, length: 15, location: 1, id: 'arrow', direction: 1}],
+          ['Label', {
+            label: newRelationship.type,
+            id: 'label',
+            labelStyle: {
+              font: '11px Roboto, sans-serif',
+              color: '#FAFAFA',
+              fill: '#303030',
+              borderStyle: '#424242',
+              borderWidth: 1,
+              padding: '3px'
+            }
+          }]
+        ],
+      });
+      conn.id = newRelationship.id;
+    }
+  }
+
+  manageRelationships(newRelationship: TRelationshipTemplate): void {
+    this.paintRelationship(newRelationship);
+    this.resetDragSource('reset previous drag source');
     this.repaintJsPlumb();
   }
 
   resetDragSource(nodeId: string): void {
     if (this.dragSourceInfos) {
       if (this.dragSourceInfos.nodeId !== nodeId) {
-        if (this.newJsPlumbInstance.isSource(this.dragSourceInfos.dragSource)) {
-          this.newJsPlumbInstance.unmakeSource(this.dragSourceInfos.dragSource);
-        }
         this.newJsPlumbInstance.removeAllEndpoints(this.dragSourceInfos.dragSource);
+        if (this.dragSourceInfos.dragSource) {
+          if (this.newJsPlumbInstance.isSource(this.dragSourceInfos.dragSource)) {
+            console.log('unmakeSource');
+            this.newJsPlumbInstance.unmakeSource(this.dragSourceInfos.dragSource);
+          }
+        }
         const indexOfNode = this.nodeChildrenIdArray.indexOf(this.dragSourceInfos.nodeId);
         if (this.nodeChildrenArray[indexOfNode]) {
           this.nodeChildrenArray[indexOfNode].connectorEndpointVisible = false;
           this.repaintJsPlumb();
         }
+        this.dragSourceActive = false;
+        this.dragSourceInfos = null;
       }
     }
-    this.dragSourceActive = false;
   }
 
   closedEndpoint(nodeId: string): void {
@@ -198,7 +290,9 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
       this.resetDragSource(nodeId);
       for (const currentNode of this.nodeChildrenArray) {
         if (currentNode.nodeAttributes.id !== nodeId) {
-          currentNode.connectorEndpointVisible = false;
+          if (currentNode.connectorEndpointVisible === true) {
+            currentNode.connectorEndpointVisible = false;
+          }
         }
       }
     }
@@ -212,15 +306,20 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
         ],
       });
       this.dragSourceInfos = dragSourceInfo;
+      console.log(this.dragSourceInfos);
       this.newJsPlumbInstance.makeTarget(this.allNodesIds);
       this.dragSourceActive = true;
+      this.bindConnection();
     }
   }
 
+
   @HostListener('document:keydown.delete', ['$event'])
   handleDeleteKeyEvent(event: KeyboardEvent) {
+    this.unbindConnection();
     for (const node of this.nodeChildrenArray) {
       if (node.makeSelectionVisible === true) {
+        this.newJsPlumbInstance.deleteConnectionsForElement(node.nodeAttributes.id);
         this.newJsPlumbInstance.removeAllEndpoints(node.nodeAttributes.id);
         this.newJsPlumbInstance.removeFromAllPosses(node.nodeAttributes.id);
         if (node.connectorEndpointVisible === true) {
@@ -236,13 +335,15 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   clearSelectedNodes(): void {
-    for (const node of this.nodeChildrenArray) {
-      if (this.selectedNodes.find(selectedNode => selectedNode.id === node.nodeAttributes.id)) {
-        node.makeSelectionVisible = false;
+    if (this.selectedNodes.length > 0) {
+      for (const node of this.nodeChildrenArray) {
+        if (this.selectedNodes.find(selectedNode => selectedNode.id === node.nodeAttributes.id)) {
+          node.makeSelectionVisible = false;
+        }
       }
+      this.newJsPlumbInstance.removeFromAllPosses(this.selectedNodes.map(node => node.id));
+      this.selectedNodes.length = 0;
     }
-    this.newJsPlumbInstance.removeFromAllPosses(this.selectedNodes.map(node => node.id));
-    this.selectedNodes.length = 0;
   }
 
   showSelectionRange($event: any) {
@@ -258,8 +359,8 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
     this.initialW = $event.pageX;
     this.initialH = $event.pageY;
     this.zone.runOutsideAngular(() => {
-      document.getElementById('container').addEventListener('mousemove', this.bindOpenSelector);
-      document.getElementById('container').addEventListener('mouseup', this.bindSelectElements);
+      this.unbindMouseMove = this.renderer.listen(this._eref.nativeElement, 'mousemove', (event) => this.openSelector(event));
+      this.unbindMouseUp = this.renderer.listen(this._eref.nativeElement, 'mouseup', (event) => this.selectElements(event));
     });
   }
 
@@ -276,15 +377,6 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
     }
   }
 
-  bindOpenSelector = (ev) => {
-    this.openSelector(ev);
-  }
-
-  bindSelectElements = (ev) => {
-    this.selectElements(ev);
-  }
-
-
   selectElements($event: any) {
     const aElem = document.getElementById('selection');
     for (const node of this.allNodeTemplates) {
@@ -294,8 +386,8 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
         this.enhanceDragSelection(node.id);
       }
     }
-    document.getElementById('container').removeEventListener('mousemove', this.bindOpenSelector);
-    document.getElementById('container').removeEventListener('mouseup', this.bindSelectElements);
+    this.unbindMouseMove();
+    this.unbindMouseUp();
     this.selectionActive = false;
     this.selectionWidth = 0;
     this.selectionHeight = 0;
@@ -349,12 +441,20 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
 
   checkFocusNode(focusNodeData: any): void {
     if (focusNodeData.ctrlKey) {
+      if (this.jsPlumbBindConnection === true) {
+        this.unbindConnection();
+      }
       if (!this.arrayContainsNode(this.selectedNodes, focusNodeData.id)) {
         this.enhanceDragSelection(focusNodeData.id);
         for (const node of this.nodeChildrenArray) {
           const nodeIndex = this.selectedNodes.map(selectedNode => selectedNode.id).indexOf(node.nodeAttributes.id);
           if (this.selectedNodes[nodeIndex] === undefined) {
             node.makeSelectionVisible = false;
+            this.unbindConnection();
+          }
+          if (node.connectorEndpointVisible === true) {
+            node.connectorEndpointVisible = false;
+            this.resetDragSource('reset previous drag source');
           }
         }
       } else {
@@ -370,7 +470,15 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
           node.makeSelectionVisible = true;
         } else if (!this.arrayContainsNode(this.selectedNodes, node.nodeAttributes.id)) {
           node.makeSelectionVisible = false;
+          this.resetDragSource(focusNodeData.id);
         }
+      }
+      this.unbindConnection();
+      if (this.selectedNodes.length === 1 && this.selectedNodes.find(node => node.id !== focusNodeData.id)) {
+        this.clearSelectedNodes();
+      }
+      if (this.selectedNodes.length === 0) {
+        this.enhanceDragSelection(focusNodeData.id);
       }
       if (!this.arrayContainsNode(this.selectedNodes, focusNodeData.id)) {
         this.clearSelectedNodes();
@@ -378,38 +486,24 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
     }
   }
 
-  updateAllNodes(nodeId: string): void {
+  updateAllNodes($event): void {
     if (this.selectedNodes.length > 0) {
-      for (const selectedNode of this.selectedNodes) {
-        const draggedSelectedNodeId = document.getElementById(selectedNode.id).id;
-        const draggedSelectedNodeLeft = document.getElementById(selectedNode.id).offsetLeft;
-        const draggedSelectedNodeTop = document.getElementById(selectedNode.id).offsetTop;
-        const draggedSelectedNode = this.allNodeTemplates.find(node => node.id === draggedSelectedNodeId);
-        const nodeCoordinates = {
-          id: draggedSelectedNodeId,
-          x: draggedSelectedNodeLeft,
-          y: draggedSelectedNodeTop
-        };
-        draggedSelectedNode.otherAttributes.x = draggedSelectedNodeLeft;
-        draggedSelectedNode.otherAttributes.y = draggedSelectedNodeTop;
-        this.ngRedux.dispatch(this.actions.updateNodeCoordinates(nodeCoordinates));
+      for (const nodeTemplate of this.child.nativeElement.children) {
+        const draggedNode = this.selectedNodes.find(node => node.id === nodeTemplate.firstChild.id);
+        if (draggedNode) {
+          const index = this.allNodeTemplates.map(node => node.id).indexOf(nodeTemplate.firstChild.id);
+          const nodeCoordinates = {
+            id: nodeTemplate.firstChild.id,
+            x: nodeTemplate.firstChild.offsetLeft,
+            y: nodeTemplate.firstChild.offsetTop
+          };
+          this.allNodeTemplates[index].otherAttributes.x = nodeCoordinates.x;
+          this.allNodeTemplates[index].otherAttributes.y = nodeCoordinates.y;
+          this.ngRedux.dispatch(this.actions.updateNodeCoordinates(nodeCoordinates));
+        }
       }
-    } else {
-      const draggedSelectedNodeId = document.getElementById(nodeId).id;
-      const draggedSelectedNodeLeft = document.getElementById(nodeId).offsetLeft;
-      const draggedSelectedNodeTop = document.getElementById(nodeId).offsetTop;
-      const draggedSelectedNode = this.allNodeTemplates.find(node => node.id === draggedSelectedNodeId);
-      const nodeCoordinates = {
-        id: draggedSelectedNodeId,
-        x: draggedSelectedNodeLeft,
-        y: draggedSelectedNodeTop
-      };
-      draggedSelectedNode.otherAttributes.x = draggedSelectedNodeLeft;
-      draggedSelectedNode.otherAttributes.y = draggedSelectedNodeTop;
-      this.ngRedux.dispatch(this.actions.updateNodeCoordinates(nodeCoordinates));
     }
   }
-
 
   private arrayContainsNode(Nodes: any[], id: string): boolean {
     if (Nodes !== null && Nodes.length > 0) {
@@ -423,9 +517,9 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private enhanceDragSelection(nodeId: string) {
-    this.newJsPlumbInstance.addToPosse(nodeId, 'dragSelection');
     if (!this.arrayContainsNode(this.selectedNodes, nodeId)) {
       this.selectedNodes.push(this.getNodeByID(this.allNodeTemplates, nodeId));
+      this.newJsPlumbInstance.addToPosse(nodeId, 'dragSelection');
       for (const node of this.nodeChildrenArray) {
         if (this.selectedNodes.find(selectedNode => selectedNode.id === node.nodeAttributes.id)) {
           node.makeSelectionVisible = true;
@@ -441,6 +535,55 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
           return node;
         }
       }
+    }
+  }
+
+  unbindDragSource(): void {
+    if (this.dragSourceInfos) {
+      this.newJsPlumbInstance.removeAllEndpoints(this.dragSourceInfos.dragSource);
+      if (this.dragSourceInfos.dragSource) {
+        if (this.newJsPlumbInstance.isSource(this.dragSourceInfos.dragSource)) {
+          console.log('unmakeSource');
+          this.newJsPlumbInstance.unmakeSource(this.dragSourceInfos.dragSource);
+        }
+      }
+      this.dragSourceActive = false;
+    }
+  }
+
+
+  unbindConnection(): void {
+    if (this.jsPlumbBindConnection === true) {
+      this.newJsPlumbInstance.unbind('connection');
+      this.jsPlumbBindConnection = false;
+      this.unbindDragSource();
+      console.log('unbind');
+    }
+  }
+
+  bindConnection(): void {
+    if (this.jsPlumbBindConnection === false) {
+      this.jsPlumbBindConnection = true;
+      this.newJsPlumbInstance.bind('connection', info => {
+        this.jsPlumbConnections.push(info.connection);
+        const sourceElement = info.source.offsetParent.offsetParent.id;
+        const targetElement = info.targetId;
+        const relationshipId = `${sourceElement}_${this.currentType}_${targetElement}`;
+        const relTypeExists = this.allRelationshipTemplates.map(rel => rel.id).includes(relationshipId);
+        if (relTypeExists === false) {
+          const newRelationship = new TRelationshipTemplate(
+            sourceElement,
+            targetElement,
+            undefined,
+            relationshipId,
+            this.currentType
+          );
+          this.ngRedux.dispatch(this.actions.saveRelationship(newRelationship));
+        }
+        this.unbindConnection();
+        this.repaintJsPlumb();
+      });
+      console.log('bind');
     }
   }
 
@@ -462,26 +605,11 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
   ngOnInit() {
     this.visuals = this.jsonService.getVisuals();
     this.assignVisuals();
-    this.newJsPlumbInstance = this.jsPlumbService.getJsPlumbInstance();
-    this.newJsPlumbInstance.setContainer('container');
-    this.newJsPlumbInstance.bind('connection', info => {
-      const sourceElement = info.source.offsetParent.offsetParent.id;
-      const targetElement = info.targetId;
-      console.log(sourceElement);
-      console.log(targetElement);
-      const newRelationship = new TRelationshipTemplate(
-        sourceElement,
-        targetElement,
-        undefined,
-        sourceElement.concat(targetElement),
-        this.currentType
-      );
-      this.ngRedux.dispatch(this.actions.saveRelationship(newRelationship));
-    });
   }
 
+
   sendCurrentType(currentType: string) {
-    this.currentType = currentType;
+    this.currentType = currentType.replace(' ', '');
   }
 
   removeElement(id: string) {
@@ -490,7 +618,7 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   repaintJsPlumb() {
-    this.newJsPlumbInstance.repaintEverything();
+    setTimeout(() => this.newJsPlumbInstance.repaintEverything(), 1);
   }
 
   makeDraggable(nodeId: string): void {
@@ -508,10 +636,12 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
     }
   }
 
+
   trackTimeOfMouseDown($event: any): void {
     this.crosshair = true;
     this.removeDragSource();
     this.clearSelectedNodes();
+    this.unbindConnection();
     this.startTime = new Date().getTime();
   }
 
@@ -542,5 +672,6 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
     this.nodeTemplatesSubscription.unsubscribe();
     this.relationshipTemplatesSubscription.unsubscribe();
     this.navBarButtonsStateSubscription.unsubscribe();
+    this.paletteOpenedSubscription.unsubscribe();
   }
 }

--- a/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/canvas/canvas.component.ts
@@ -82,6 +82,8 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
   currentPaletteOpenedState: boolean;
   makeNewNodeSelectionVisible: any;
   newNodeData: any;
+  allRelationshipTypes: Array<string> = [];
+  allRelationshipTypesColors: Array<any> = [];
 
   constructor(private jsPlumbService: JsPlumbService,
               private jsonService: JsonService,
@@ -119,6 +121,7 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
         this.newNode = currentNodes[currentNodes.length - 1];
         this.unbindConnection();
         this.clearSelectedNodes();
+        this.resetDragSource(this.newNode.id);
         this.repaintConnections();
         if (this.currentPaletteOpenedState) {
           this.addNewNodeToDragSelection(this.newNode.id, currentNodes);
@@ -194,6 +197,8 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
 
   updateRelationships(currentRelationships: Array<TRelationshipTemplate>): void {
     this.allRelationshipTemplates = currentRelationships;
+    this.allRelationshipTemplates.map(rel => !this.allRelationshipTypes.includes(rel.type) ?
+      this.allRelationshipTypes.push(rel.type) : null);
     setTimeout(() => {
       if (this.allRelationshipTemplates.length > 0) {
         for (const relationship of this.allRelationshipTemplates) {
@@ -252,6 +257,7 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
         ],
       });
       conn.id = newRelationship.id;
+      conn.setType(newRelationship.type);
     }
   }
 
@@ -306,7 +312,6 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
         ],
       });
       this.dragSourceInfos = dragSourceInfo;
-      console.log(this.dragSourceInfos);
       this.newJsPlumbInstance.makeTarget(this.allNodesIds);
       this.dragSourceActive = true;
       this.bindConnection();
@@ -542,7 +547,6 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
       this.newJsPlumbInstance.removeAllEndpoints(this.dragSourceInfos.dragSource);
       if (this.dragSourceInfos.dragSource) {
         if (this.newJsPlumbInstance.isSource(this.dragSourceInfos.dragSource)) {
-          console.log('unmakeSource');
           this.newJsPlumbInstance.unmakeSource(this.dragSourceInfos.dragSource);
         }
       }
@@ -556,7 +560,6 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
       this.newJsPlumbInstance.unbind('connection');
       this.jsPlumbBindConnection = false;
       this.unbindDragSource();
-      console.log('unbind');
     }
   }
 
@@ -582,7 +585,6 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
         this.unbindConnection();
         this.repaintJsPlumb();
       });
-      console.log('bind');
     }
   }
 
@@ -601,9 +603,30 @@ export class CanvasComponent implements OnInit, OnDestroy, AfterViewInit {
     }
   }
 
+  assignRelTypes(): void {
+    if (this.allRelationshipTypes.length > 0) {
+      for (const rel of this.allRelationshipTypes) {
+        const color = '#' + (0x1000000 + Math.floor(Math.random() * 0x1000000)).toString(16).substr(1);
+        this.allRelationshipTypesColors.push({
+          type: rel,
+          color: '0 0 2px ' + color
+        });
+        this.newJsPlumbInstance.registerConnectionType(
+          rel, {
+            paintStyle: {
+              stroke: color,
+              strokeWidth: 2
+            },
+            hoverPaintStyle: {stroke: 'red', strokeWidth: 5}
+          });
+      }
+    }
+  }
+
   ngOnInit() {
     this.visuals = this.jsonService.getVisuals();
     this.assignVisuals();
+    this.assignRelTypes();
   }
 
 

--- a/org.eclipse.winery.topologymodeler.ui/src/app/jsPlumbService.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/jsPlumbService.ts
@@ -29,7 +29,7 @@ export class JsPlumbService {
         ['Arrow', {location: 1}],
       ],
       ConnectionsDetachable: false,
-      Anchor: ['Perimeter', { shape: 'Rectangle'}]
+      Anchor: 'Continuous'
     });
   }
 }

--- a/org.eclipse.winery.topologymodeler.ui/src/app/jsPlumbService.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/jsPlumbService.ts
@@ -15,7 +15,6 @@ declare const jsPlumb: any;
 
 @Injectable()
 export class JsPlumbService {
-
   getJsPlumbInstance(): any {
     jsPlumb.ready(() => {
     });

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.css
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.css
@@ -3,7 +3,7 @@ div.container {
   font-size: small;
   box-shadow: 2px 2px 10px -2px rgba(0, 0, 0, 0.75);
   cursor: pointer;
-  z-index: 20;
+  z-index: 501;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.css
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.css
@@ -66,7 +66,9 @@ div.endpointContainer {
 
 div.connectorEndpoint {
   width: 206px !important;
+  font-weight: bold;
   cursor: pointer;
+  text-align: center;
 }
 
 div.connectorEndpoint:hover {
@@ -77,6 +79,8 @@ div.connectorEndpoint:hover {
 
 div.connectorBox {
   height: 15px;
+  width: 30px;
+  float: left;
 }
 
 div.connectorLabel {

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.html
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.html
@@ -34,13 +34,13 @@
   <div class="endpointContainer container rounded" [style.border-color]="this.nodeAttributes.color" style="width: 100%" *ngIf="connectorEndpointVisible"
        (mouseover)="makeSource($event)">
     <div class="btn-group-vertical btn-group-sm" role="group" id={{dragSource}} (mousedown)="passCurrentType($event)">
-        <button *ngFor="let relationshipType of relationshipTypes;"
-                type="button" class="btn btn-sm btn-outline-secondary relationship-button sm"
-                [style.border-color]="this.nodeAttributes.color"
-                style="font-size: x-small;">
-          {{relationshipType}}
+        <button *ngFor="let rel of allRelationshipTypesColors"
+             type="button" class="btn btn-sm btn-outline-secondary relationship-button sm"
+             [style.border-color]="this.nodeAttributes.color" [style.text-shadow] = "rel.color"
+             style="font-size: x-small">
+          {{rel.type}}
         </button>
-    </div>
+  </div>
   </div>
 
   <!-- Repaint jsPlumb on every accordion click -->

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.ts
@@ -55,6 +55,7 @@ export class NodeComponent implements OnInit, AfterViewInit, OnDestroy, DoCheck 
   @Output() updateAllNodes: EventEmitter<string>;
   @Output() sendCurrentType: EventEmitter<string>;
   @Output() askForRemoval: EventEmitter<string>;
+  @Output() unmarkConnections: EventEmitter<string>;
   @Input() makeNewNodeSelectionVisible: any;
   previousPosition: any;
   currentPosition: any;
@@ -81,6 +82,7 @@ export class NodeComponent implements OnInit, AfterViewInit, OnDestroy, DoCheck 
     this.updateAllNodes = new EventEmitter();
     this.sendCurrentType = new EventEmitter();
     this.askForRemoval = new EventEmitter();
+    this.unmarkConnections = new EventEmitter();
     this.differ = differs.find([]).create(null);
   }
 
@@ -104,6 +106,7 @@ export class NodeComponent implements OnInit, AfterViewInit, OnDestroy, DoCheck 
   }
 
   mouseDownHandler($event): void {
+    this.unmarkConnections.emit('unmark');
     this.startTime = new Date().getTime();
     this.repaint(new Event('repaint'));
     const focusNodeData = {
@@ -185,16 +188,27 @@ export class NodeComponent implements OnInit, AfterViewInit, OnDestroy, DoCheck 
       this.$ngRedux.dispatch(this.actions.openSidebar({
         sidebarContents: {
           sidebarVisible: false,
-          nodeId: '',
-          nameTextFieldValue: ''
+          nodeClicked: true,
+          id: '',
+          nameTextFieldValue: '',
+          type: ''
         }
       }));
     } else {
+      let type;
+      const id = this.nodeAttributes.id;
+      if ( id.includes ('_') ) {
+        type = id.substring(0, id.indexOf('_'));
+      } else {
+        type = id;
+      }
       this.$ngRedux.dispatch(this.actions.openSidebar({
         sidebarContents: {
           sidebarVisible: true,
-          nodeId: this.nodeAttributes.id,
-          nameTextFieldValue: this.nodeAttributes.name
+          nodeClicked: true,
+          id: this.nodeAttributes.id,
+          nameTextFieldValue: this.nodeAttributes.name,
+          type: type
         }
       }));
     }

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.ts
@@ -58,8 +58,7 @@ export class NodeComponent implements OnInit, AfterViewInit, OnDestroy, DoCheck 
   @Input() makeNewNodeSelectionVisible: any;
   previousPosition: any;
   currentPosition: any;
-  @Input() relationshipTemplates: Array<TRelationshipTemplate>;
-  relationshipTypes = [];
+  @Input() allRelationshipTypesColors: Array<string>;
   nodeRef: ComponentRef<Component>;
   unbindMouseMove: Function;
   differ: any;
@@ -86,7 +85,6 @@ export class NodeComponent implements OnInit, AfterViewInit, OnDestroy, DoCheck 
   }
 
   ngOnInit() {
-    this.relationshipTemplates.map(rt => !this.relationshipTypes.includes(rt.type) ? this.relationshipTypes.push(rt.type) : null);
   }
 
   ngAfterViewInit(): void {

--- a/org.eclipse.winery.topologymodeler.ui/src/app/redux/actions/winery.actions.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/redux/actions/winery.actions.ts
@@ -28,7 +28,7 @@ export interface SidebarStateAction extends Action {
 export interface SidebarNodeNamechange extends Action {
   nodeNames: {
     newNodeName: string,
-    oldNodeName: string
+    id: string
   };
 }
 

--- a/org.eclipse.winery.topologymodeler.ui/src/app/redux/actions/winery.actions.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/redux/actions/winery.actions.ts
@@ -20,8 +20,10 @@ export interface SendPaletteOpenedAction extends Action {
 export interface SidebarStateAction extends Action {
   sidebarContents: {
     sidebarVisible: boolean,
-    nodeId: string,
-    nameTextFieldValue: string
+    nodeClicked: boolean,
+    id: string,
+    nameTextFieldValue: string,
+    type: string
   };
 }
 
@@ -48,6 +50,13 @@ export interface DeleteNodeAction extends Action {
   nodeTemplateId: string;
 }
 
+export interface UpdateRelationshipNameAction extends Action {
+  relData: {
+    newRelName: string,
+    id: string
+  };
+}
+
 @Injectable()
 export class WineryActions {
 
@@ -58,6 +67,7 @@ export class WineryActions {
     static CHANGE_NODE_NAME = 'CHANGE_NODE_NAME';
     static OPEN_SIDEBAR = 'OPEN_SIDEBAR';
     static UPDATE_NODE_COORDINATES = 'UPDATE_NODE_COORDINATES';
+    static UPDATE_REL_DATA = 'UPDATE_REL_DATA';
 
     sendPaletteOpened: ActionCreator<SendPaletteOpenedAction> =
       ((paletteOpened) => ({
@@ -93,5 +103,10 @@ export class WineryActions {
       ((currentNodeCoordinates) => ({
         type: WineryActions.UPDATE_NODE_COORDINATES,
         otherAttributes: currentNodeCoordinates
+      }));
+    updateRelationshipName: ActionCreator<UpdateRelationshipNameAction> =
+      ((currentRelData) => ({
+        type: WineryActions.UPDATE_REL_DATA,
+        relData: currentRelData.relData
       }));
 }

--- a/org.eclipse.winery.topologymodeler.ui/src/app/redux/reducers/winery.reducer.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/redux/reducers/winery.reducer.ts
@@ -16,8 +16,10 @@ import {
   SaveRelationshipAction,
   SendPaletteOpenedAction,
   SidebarNodeNamechange,
-  SidebarStateAction, UpdateNodeCoordinatesAction,
-  WineryActions
+  SidebarStateAction,
+  UpdateNodeCoordinatesAction,
+  WineryActions,
+  UpdateRelationshipNameAction
 } from '../actions/winery.actions';
 import { TNodeTemplate, TRelationshipTemplate, TTopologyTemplate } from 'app/ttopology-template';
 
@@ -31,8 +33,10 @@ export const INITIAL_WINERY_STATE: WineryState = {
   currentPaletteOpenedState: false,
   sidebarContents: {
     sidebarVisible: false,
-    nodeId: '',
-    nameTextFieldValue: ''
+    nodeClicked: false,
+    id: '',
+    nameTextFieldValue: '',
+    type: ''
   },
   currentJsonTopology: new TTopologyTemplate
 };
@@ -59,6 +63,7 @@ export const WineryReducer =
       case WineryActions.CHANGE_NODE_NAME:
         const nodeNames: any = (<SidebarNodeNamechange>action).nodeNames;
         const index = lastState.currentJsonTopology.nodeTemplates.map(el => el.id).indexOf(nodeNames.id);
+        /*
         console.log(index);
         console.log(nodeNames);
         console.log({
@@ -85,6 +90,7 @@ export const WineryReducer =
             )
           }
         });
+        */
         return {
           ...lastState,
           currentJsonTopology: {
@@ -167,7 +173,26 @@ export const WineryReducer =
               relationshipTemplate.targetElement !== deletedNodeId)
           }
         };
+      case WineryActions.UPDATE_REL_DATA:
+        const relData: any = (<UpdateRelationshipNameAction>action).relData;
+        const indexRel = lastState.currentJsonTopology.relationshipTemplates.map(rel => rel.id).indexOf(relData.id);
+        return {
+          ...lastState,
+          currentJsonTopology: {
+            ...lastState.currentJsonTopology,
+            relationshipTemplates: lastState.currentJsonTopology.relationshipTemplates.map(relTemplate => relTemplate.id === relData.id ?
+              new TRelationshipTemplate(
+                lastState.currentJsonTopology.relationshipTemplates[indexRel].sourceElement,
+                lastState.currentJsonTopology.relationshipTemplates[indexRel].targetElement,
+                relData.newRelName,
+                lastState.currentJsonTopology.relationshipTemplates[indexRel].id,
+                lastState.currentJsonTopology.relationshipTemplates[indexRel].type,
+              ) : relTemplate
+            )
+          }
+        };
       default:
         return lastState;
     }
   };
+

--- a/org.eclipse.winery.topologymodeler.ui/src/app/redux/reducers/winery.reducer.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/redux/reducers/winery.reducer.ts
@@ -58,15 +58,15 @@ export const WineryReducer =
         };
       case WineryActions.CHANGE_NODE_NAME:
         const nodeNames: any = (<SidebarNodeNamechange>action).nodeNames;
-        const index = lastState.currentJsonTopology.nodeTemplates.map(el => el.name).indexOf(nodeNames.oldNodeName);
+        const index = lastState.currentJsonTopology.nodeTemplates.map(el => el.id).indexOf(nodeNames.id);
         console.log(index);
         console.log(nodeNames);
         console.log({
           ...lastState,
           currentJsonTopology: {
             ...lastState.currentJsonTopology,
-            nodeTemplates: lastState.currentJsonTopology.nodeTemplates.map(nodeTemplate => nodeTemplate.name === nodeNames.oldNodeName ?
-              nodeTemplate = new TNodeTemplate(
+            nodeTemplates: lastState.currentJsonTopology.nodeTemplates.map(nodeTemplate => nodeTemplate.id === nodeNames.id ?
+              new TNodeTemplate(
                 lastState.currentJsonTopology.nodeTemplates[index].properties,
                 // id
                 lastState.currentJsonTopology.nodeTemplates[index].id,
@@ -89,7 +89,7 @@ export const WineryReducer =
           ...lastState,
           currentJsonTopology: {
             ...lastState.currentJsonTopology,
-            nodeTemplates: lastState.currentJsonTopology.nodeTemplates.map(nodeTemplate => nodeTemplate.name === nodeNames.oldNodeName ?
+            nodeTemplates: lastState.currentJsonTopology.nodeTemplates.map(nodeTemplate => nodeTemplate.id === nodeNames.id ?
               new TNodeTemplate(
                 lastState.currentJsonTopology.nodeTemplates[index].properties,
                 // id

--- a/org.eclipse.winery.topologymodeler.ui/src/app/sidebar/sidebar.component.html
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/sidebar/sidebar.component.html
@@ -11,7 +11,7 @@
     <fieldset>
       <div class="form-group">
         <label for="nodetemplateid">Id</label>
-        <input id="nodetemplateid" disabled="disabled" class="form-control" value="{{sidebarState.nodeId}}">
+        <input id="nodetemplateid" disabled="disabled" class="form-control" value="{{sidebarState.id}}">
       </div>
       <div class="form-group">
         <label for="nodetemplatename" class="control-label">Name</label>
@@ -24,10 +24,11 @@
            target="_blank"
            href="http://dev.winery.opentosca.org/winery/nodetypes/http%253A%252F%252Fopentosca.org%252Fnodetypes/Babel/"
            class="form-control">
-          {{sidebarState.nodeId}}
+          {{sidebarState.type}}
         </a>
       </div>
       <div class="form-group">
+        <div *ngIf="sidebarState.nodeClicked; else relClicked">
         <label for="minInstances">min</label>
         <div class="row">
           <div class="col-lg-12">
@@ -86,6 +87,64 @@
             </div>
           </div>
         </div>
+        </div>
+        <ng-template #relClicked>
+          <label for="requirements">Requirement</label>
+          <div class="row">
+            <div class="col-lg-12">
+              <div class="input-sm">
+                <div class="input-group bootstrap-touchspin">
+                <span class="input-group-addon bootstrap-touchspin-prefix"
+                      style="display: none;">
+                </span>
+                  <input id="requirements"
+                         value=""
+                         name="requirements"
+                         class="form-control"
+                         style="display: block; border-radius: 0.25rem; margin-right: 3px"
+                         type="text">
+                  <span class="input-group-addon bootstrap-touchspin-postfix" style="display: none;"></span>
+                  <span class="input-group-btn-vertical">
+                  <button class="btn btn-default bootstrap-touchspin-up" type="button">
+                    <i class="fa fa-chevron-up"></i>
+                  </button>
+                  <button class="btn btn-default bootstrap-touchspin-down"
+                          type="button">
+                    <i class="fa fa-chevron-down"></i>
+                  </button>
+                </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <label for="capabilities">Capability</label>
+          <div class="row">
+            <div class="col-lg-12">
+              <div class="input-sm">
+                <div class="input-group bootstrap-touchspin">
+                <span class="input-group-addon bootstrap-touchspin-prefix"
+                      style="display: none;">
+                </span>
+                  <input id="capabilities"
+                         value=""
+                         name="capabilities"
+                         class="form-control"
+                         style="display: block; border-radius: 0.25rem; margin-right: 3px"
+                         type="text">
+                  <span class="input-group-addon bootstrap-touchspin-postfix" style="display: none;"></span>
+                  <span class="input-group-btn-vertical">
+                  <button class="btn btn-default bootstrap-touchspin-up" type="button">
+                    <i class="fa fa-chevron-up"></i>
+                  </button>
+                  <button class="btn btn-default bootstrap-touchspin-down" type="button">
+                    <i class="fa fa-chevron-down"></i>
+                  </button>
+                </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </ng-template>
       </div>
     </fieldset>
   </div>

--- a/org.eclipse.winery.topologymodeler.ui/src/app/sidebar/sidebar.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/sidebar/sidebar.component.ts
@@ -45,8 +45,10 @@ export class SidebarComponent implements OnInit {
     this.$ngRedux.dispatch(this.actions.openSidebar({
       sidebarContents: {
         sidebarVisible: false,
-        nodeId: '',
-        nameTextFieldValue: ''
+        nodeClicked: false,
+        id: '',
+        nameTextFieldValue: '',
+        type: ''
       }
     }));
   };
@@ -55,6 +57,9 @@ export class SidebarComponent implements OnInit {
     this.sidebarSubscription = this.$ngRedux.select(state => state.wineryState.sidebarContents)
       .subscribe(newValue => {
           this.sidebarState = newValue;
+          if (!this.sidebarState.nameTextFieldValue) {
+            this.sidebarState.nameTextFieldValue = this.sidebarState.id;
+          }
           if (newValue.sidebarVisible) {
             this.sidebarAnimationStatus = 'in';
           }
@@ -69,19 +74,29 @@ export class SidebarComponent implements OnInit {
       .debounceTime(300)
       .distinctUntilChanged()
       .subscribe(data => {
-        this.$ngRedux.dispatch(this.actions.changeNodeName({
-          nodeNames: {
-            newNodeName: data,
-            id: this.sidebarState.nodeId
-          }
-        }));
-        console.log(this.sidebarState.nodeId);
+        if (this.sidebarState.nodeClicked) {
+          this.$ngRedux.dispatch(this.actions.changeNodeName({
+            nodeNames: {
+              newNodeName: data,
+              id: this.sidebarState.id
+            }
+          }));
+        } else {
+          this.$ngRedux.dispatch(this.actions.updateRelationshipName({
+            relData: {
+              newRelName: data,
+              id: this.sidebarState.id
+            }
+          }));
+        }
         // refresh
         this.$ngRedux.dispatch(this.actions.openSidebar({
           sidebarContents: {
             sidebarVisible: true,
-            nodeId: this.sidebarState.nodeId,
-            nameTextFieldValue: data
+            nodeClicked: true,
+            id: this.sidebarState.id,
+            nameTextFieldValue: data,
+            type: this.sidebarState.type
           }
         }));
       });

--- a/org.eclipse.winery.topologymodeler.ui/src/app/sidebar/sidebar.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/sidebar/sidebar.component.ts
@@ -93,7 +93,7 @@ export class SidebarComponent implements OnInit {
         this.$ngRedux.dispatch(this.actions.openSidebar({
           sidebarContents: {
             sidebarVisible: true,
-            nodeClicked: true,
+            nodeClicked: this.sidebarState.nodeClicked,
             id: this.sidebarState.id,
             nameTextFieldValue: data,
             type: this.sidebarState.type

--- a/org.eclipse.winery.topologymodeler.ui/src/app/sidebar/sidebar.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/sidebar/sidebar.component.ts
@@ -71,10 +71,11 @@ export class SidebarComponent implements OnInit {
       .subscribe(data => {
         this.$ngRedux.dispatch(this.actions.changeNodeName({
           nodeNames: {
-            oldNodeName: this.sidebarState.nameTextFieldValue,
-            newNodeName: data
+            newNodeName: data,
+            id: this.sidebarState.nodeId
           }
         }));
+        console.log(this.sidebarState.nodeId);
         // refresh
         this.$ngRedux.dispatch(this.actions.openSidebar({
           sidebarContents: {

--- a/org.eclipse.winery.topologymodeler.ui/src/app/winery.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/winery.component.ts
@@ -110,17 +110,17 @@ export class WineryComponent implements OnInit {
       {
         'sourceElement': 'baobab',
         'targetElement': 'tree',
-        'type': 'hosted on'
+        'type': 'hostedOn'
       },
       {
         'sourceElement': 'banana',
         'targetElement': 'baobab',
-        'type': 'installed on'
+        'type': 'installedOn'
       },
       {
         'sourceElement': 'mango',
         'targetElement': 'tree',
-        'type': 'hosted on'
+        'type': 'hostedOn'
       },
       {
         'sourceElement': 'banana',
@@ -276,13 +276,14 @@ export class WineryComponent implements OnInit {
       this.ngRedux.dispatch(this.actions.saveNodeTemplate(nodeTemplate));
     }
     for (const relationship of this.testJson.relationshipTemplates) {
+      const relationshipType = relationship.type.replace(' ', '');
       this.relationshipTemplates.push(
         new TRelationshipTemplate(
           relationship.sourceElement,
           relationship.targetElement,
           undefined,
-          relationship.sourceElement.concat(relationship.targetElement),
-          relationship.type
+          `${relationship.sourceElement}_${relationshipType}_${relationship.targetElement}`,
+          relationshipType
         )
       );
     }

--- a/org.eclipse.winery.topologymodeler.ui/src/app/winery.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/winery.component.ts
@@ -17,7 +17,7 @@ import { WineryActions } from './redux/actions/winery.actions';
 import { NgRedux } from '@angular-redux/store';
 import { ILoaded, LoadedService } from './loaded.service';
 import { AppReadyEventService } from './app-ready-event.service';
-import { Hotkey, HotkeyModule, HotkeysService } from 'angular2-hotkeys';
+import { HotkeysService } from 'angular2-hotkeys';
 
 @Component({
   selector: 'winery-topologymodeler',
@@ -110,27 +110,27 @@ export class WineryComponent implements OnInit {
       {
         'sourceElement': 'baobab',
         'targetElement': 'tree',
-        'type': 'hostedOn'
+        'type': 'hostedOn',
       },
       {
         'sourceElement': 'banana',
         'targetElement': 'baobab',
-        'type': 'installedOn'
+        'type': 'installedOn',
       },
       {
         'sourceElement': 'mango',
         'targetElement': 'tree',
-        'type': 'hostedOn'
+        'type': 'hostedOn',
       },
       {
         'sourceElement': 'banana',
         'targetElement': 'mango',
-        'type': 'requires'
+        'type': 'requires',
       },
       {
         'sourceElement': 'baobab',
         'targetElement': 'plantage',
-        'type': 'extends'
+        'type': 'extends',
       }
     ]
   };
@@ -228,8 +228,7 @@ export class WineryComponent implements OnInit {
   constructor(private ngRedux: NgRedux<IWineryState>,
               private actions: WineryActions,
               private loadedService: LoadedService,
-              private appReadyEvent: AppReadyEventService,
-              private hotkeysService: HotkeysService) {
+              private appReadyEvent: AppReadyEventService) {
 
     this.loaded = null;
     loadedService.getLoadingState()


### PR DESCRIPTION
- Fixed the selection functionality with ctrl key
- Replaced all 'document.getElementyById' with Angular methods
- Fixed all JsPlumb repaint issues
- Cleared all JsPlumb warnings
- Refactoring
- Other small Bug fixes
- Added relationships types for unique colorization
- Possible now to generate and drag new nodes from the palette with one click
- Opening of the sidebar when clicking on a relationship with all its properties
- Changed relationship names are stored into the store
- Relationships can only now be deleted by deleting one of the nodes 
- Multiple different connections between 2 nodes are possible now

- Start and end date:  2017-10-09 to 2017-10-20 

- Contributor: Thommy Zelenik, @zelenikty
- Supervisor: Oliver Kopp, @koppor
