### PR TITLE
Add markdown-parser for readme component

### DIFF
--- a/org.eclipse.winery.repository.ui/package.json
+++ b/org.eclipse.winery.repository.ui/package.json
@@ -29,6 +29,7 @@
         "@angular/platform-browser-dynamic": "4.3.5",
         "@angular/router": "4.3.5",
         "angular2-websocket": "0.9.3",
+        "angular2-markdown": "1.6.0",
         "core-js": "2.5.0",
         "font-awesome": "4.7.0",
         "ngx-chips": "1.5.3",

--- a/org.eclipse.winery.repository.ui/src/app/wineryMarkdownComponent/wineryMarkdown.component.css
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMarkdownComponent/wineryMarkdown.component.css
@@ -1,0 +1,103 @@
+/**
+* SPDX-License-Identifier: MIT
+*
+* Taken from: https://github.com/dimpu/angular2-markdown/blob/1c36831d2c9f48ddd7183db33e886ed9ab0a3345/demo/src/app/home/home.component.ts#L11
+*/
+
+#textbox {
+    width: 100%;
+    height: 100vh;
+}
+
+table.table2 {
+    font-size: 14px;
+    color: #212121;
+    margin: 0 auto;
+    border-collapse: collapse;
+}
+
+table.table2 thead th {
+    font-size: 20px;
+    color: #212121;
+    height: 40px;
+    border: 1px solid #e6e6e6;
+    border-top: 0;
+    border-right: 0;
+    border-left: 0;
+}
+
+table.table2 tbody tr:nth-child(odd) {
+    background-color: #f6f6f6;
+}
+
+table.table2 td {
+    height: 40px;
+    width: 230px;
+    border-bottom: 1px solid #e6e6e6;
+    border-right: 1px solid #e6e6e6;
+}
+
+table.table2 td:last-of-type {
+    border-right: 0;
+}
+
+/* From https://codepen.io/maxds/pen/DcveB */
+blockquote.king-quote {
+    display: block;
+    background: #fff;
+    padding: 15px 20px 15px 45px;
+    margin: 0 0 20px;
+    position: relative;
+
+    /*Font*/
+    font-family: Georgia, serif;
+    font-size: 16px;
+    line-height: 1.2;
+    color: #666;
+    text-align: justify;
+
+    /*Borders - (Optional)*/
+    border-left: 15px solid #c76c0c;
+    border-right: 2px solid #c76c0c;
+
+    /*Box Shadow - (Optional)*/
+    -moz-box-shadow: 2px 2px 15px #ccc;
+    -webkit-box-shadow: 2px 2px 15px #ccc;
+    box-shadow: 2px 2px 15px #ccc;
+}
+
+blockquote.king-quote::before {
+    content: "\201C"; /*Unicode for Left Double Quote*/
+
+    /*Font*/
+    font-family: Georgia, serif;
+    font-size: 60px;
+    font-weight: bold;
+    color: #999;
+
+    /*Positioning*/
+    position: absolute;
+    left: 10px;
+    top: 5px;
+}
+
+blockquote.king-quote::after {
+    /*Reset to make sure*/
+    content: "";
+}
+
+blockquote.king-quote a {
+    text-decoration: none;
+    background: #eee;
+    cursor: pointer;
+    padding: 0 3px;
+    color: #c76c0c;
+}
+
+blockquote.king-quote a:hover {
+    color: #666;
+}
+
+blockquote.king-quote em {
+    font-style: italic;
+}

--- a/org.eclipse.winery.repository.ui/src/app/wineryMarkdownComponent/wineryMarkdown.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMarkdownComponent/wineryMarkdown.component.html
@@ -1,3 +1,4 @@
+<!--
 /**
  * Copyright (c) 2017 University of Stuttgart.
  * All rights reserved. This program and the accompanying materials
@@ -6,21 +7,6 @@
  * and are available at http://www.eclipse.org/legal/epl-v20.html
  * and http://www.apache.org/licenses/LICENSE-2.0
  */
+-->
 
-.flash{
-    background-color: #dbedff;
-    padding: 16px;
-    display: inline-block;
-    border: 1px solid rgba(27,31,35,0.15);
-    border-radius: 3px;
-    font-size: larger;
-}
-
-.flash-action {
-    background-image: linear-gradient(#79d858, #569e3d);
-    border-color: #569e3d;
-}
-
-.pad-6px {
-    padding: 6px;
-}
+<markdown [data]='markdownContent'></markdown>

--- a/org.eclipse.winery.repository.ui/src/app/wineryMarkdownComponent/wineryMarkdown.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMarkdownComponent/wineryMarkdown.component.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
+import { MarkdownService } from 'angular2-markdown';
+
+@Component({
+    selector: 'winery-markdown',
+    encapsulation: ViewEncapsulation.None,
+    templateUrl: './wineryMarkdown.component.html',
+    providers: [],
+    styleUrls: ['wineryMarkdown.component.css'],
+
+})
+export class WineryMarkdownComponent implements OnInit {
+
+    @Input() markdownContent = '';
+
+    constructor(private _markdown: MarkdownService) {
+    }
+
+    ngOnInit() {
+        this._markdown.setMarkedOptions({});
+        this._markdown.setMarkedOptions({
+            gfm: true,
+            tables: true,
+            breaks: false,
+            pedantic: false,
+            sanitize: false,
+            smartLists: true,
+            smartypants: false
+        });
+
+        this._markdown.renderer.table = (header: string, body: string) => {
+            return `
+        <table class="table2">
+          <thead>
+            ${header}
+          </thead>
+          <tbody>
+            ${body}
+          </tbody>
+        </table>
+        `;
+        };
+        this._markdown.renderer.blockquote = (quote: string) => {
+            return `<blockquote class="king-quote">${quote}</blockquote>`;
+        };
+    }
+
+}

--- a/org.eclipse.winery.repository.ui/src/app/wineryMarkdownComponent/wineryMarkdown.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMarkdownComponent/wineryMarkdown.module.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2017 University of Stuttgart.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and the Apache License 2.0 which both accompany this distribution,
+ * and are available at http://www.eclipse.org/legal/epl-v20.html
+ * and http://www.apache.org/licenses/LICENSE-2.0
+ */
+import { NgModule } from '@angular/core';
+
+import { FormsModule } from '@angular/forms';
+import { BrowserModule } from '@angular/platform-browser';
+import { WineryMarkdownComponent } from './wineryMarkdown.component';
+import { MarkdownModule } from 'angular2-markdown';
+
+@NgModule({
+    imports: [
+        FormsModule,
+        BrowserModule,
+        MarkdownModule.forRoot(),
+
+    ],
+    exports: [WineryMarkdownComponent],
+    declarations: [WineryMarkdownComponent],
+    providers: [],
+})
+export class WineryMarkdownModule {
+}

--- a/org.eclipse.winery.repository.ui/src/app/wineryReadmeModule/wineryReadme.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/wineryReadmeModule/wineryReadme.component.html
@@ -19,20 +19,63 @@
 </div>
 
 <div *ngIf="!isEditable && readmeAvailable">
-    <div class="right" style="width: 100%; margin-bottom: 2px; ">
-        <button class="btn fa fa-pencil" aria-hidden="true" name="edit" style="float: right;"
-                (click)="isEditable = true;"></button>
+    <div class="right">
+        <button class="btn fa fa-pencil" aria-hidden="true" name="edit" (click)="isEditable = true;"></button>
     </div>
-    <textarea readonly tabIndex="-1" style="width: 95%;height: 500px; resize: none;">{{readmeContent}}</textarea>
+    <winery-markdown [markdownContent]="readmeContent"></winery-markdown>
+
 </div>
 
 <div *ngIf="isEditable">
-    <div class="right" style="margin-bottom: 2px;">
+    <div class="right">
         <button class="btn fa fa-floppy-o" aria-hidden="true" name="save" (click)="saveReadmeFile()"> Save</button>
-        <button class="btn fa fa-ban" name="cancel" aria-hidden="true" (click)="cancelEdit()"> Cancel</button>
+        <button class="btn fa fa-ban" name="cancel" aria-hidden="true" (click)="cancelEdit()">
+            Cancel</button>
     </div>
 
-    <textarea style="width: 95%; height: 500px; resize: none; font-family: monospace" [(ngModel)]="readmeContent"></textarea>
+    <div>
+        <tabset #markdownTabs>
+            <tab heading="Edit File" active="true">
+                <div>
+                    <form>
+                        <textarea name="readmeEdit" id="textbox" class="form-control pad-6px"
+                                  style="min-height: -webkit-fill-available; font-family: monospace"
+                                  [(ngModel)]="readmeContent"></textarea>
+                    </form>
+                </div>
+            </tab>
+
+            <tab heading="Preview Changes">
+                <div class="panel-body">
+                    <winery-markdown [markdownContent]="readmeContent"></winery-markdown>
+                </div>
+            </tab>
+
+            <tab heading="Both">
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6" style="padding-left: 0px">
+                            <div class="panel panel-default">
+                            <textarea name="readmeEditBoth" id="textbox_b" class="form-control pad-6px"
+                                      style="min-height: -webkit-fill-available; font-family: monospace"
+                                      [(ngModel)]="readmeContent"></textarea>
+                            </div>
+
+                        </div>
+                        <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6" style="padding-left: 0px">
+                            <div class="panel panel-default">
+                                <div class="panel-body pad-6px" style="min-height: -webkit-fill-available;
+                                     max-height: -webkit-fill-available; overflow-y: scroll;">
+                                    <winery-markdown [markdownContent]="readmeContent"></winery-markdown>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </tab>
+        </tabset>
+    </div>
+
 </div>
 
 

--- a/org.eclipse.winery.repository.ui/src/app/wineryReadmeModule/wineryReadme.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryReadmeModule/wineryReadme.module.ts
@@ -12,6 +12,7 @@ import { WineryReadmeComponent } from './wineryReadme.component';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { WineryLoaderModule } from '../wineryLoader/wineryLoader.module';
+import { WineryMarkdownModule } from '../wineryMarkdownComponent/wineryMarkdown.module';
 import { TabsModule } from 'ngx-bootstrap';
 import { WineryPipesModule } from '../wineryPipes/wineryPipes.module';
 
@@ -20,6 +21,7 @@ import { WineryPipesModule } from '../wineryPipes/wineryPipes.module';
         CommonModule,
         WineryLoaderModule,
         FormsModule,
+        WineryMarkdownModule,
         TabsModule,
         WineryPipesModule
     ],


### PR DESCRIPTION
Add markdown-parser for readme-component, based on the library ng2-markdown.

Library:
ng2-markdown: https://www.npmjs.com/package/ng2-markdown

![grafik](https://user-images.githubusercontent.com/23094908/31028753-7673993a-a54f-11e7-8799-2c06ad87472c.png)
