### PR TITLE
[WIP] adds feature to set inheritance between Service Templates

### DIFF
--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TServiceTemplate.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TServiceTemplate.java
@@ -16,18 +16,23 @@ package org.eclipse.winery.model.tosca;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.winery.model.tosca.constants.Namespaces;
 
 import javax.xml.bind.annotation.*;
 import javax.xml.namespace.QName;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
-
 /**
- * <p>Java class for tServiceTemplate complex type.
  * <p>
- * <p>The following schema fragment specifies the expected content contained within this class.
+ * Java class for tServiceTemplate complex type.
  * <p>
+ * <p>
+ * The following schema fragment specifies the expected content contained within
+ * this class.
+ * <p>
+ * 
  * <pre>
  * &lt;complexType name="tServiceTemplate">
  *   &lt;complexContent>
@@ -50,249 +55,281 @@ import java.util.Objects;
  * </pre>
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "tServiceTemplate", propOrder = {
-    "tags",
-    "boundaryDefinitions",
-    "topologyTemplate",
-    "plans"
-})
+@XmlType(name = "tServiceTemplate", propOrder = { "tags", "boundaryDefinitions", "topologyTemplate", "plans" })
 public class TServiceTemplate extends HasId implements HasName, HasTargetNamespace {
 
-    @XmlElement(name = "Tags")
-    protected TTags tags;
+	@XmlElement(name = "Tags")
+	protected TTags tags;
 
-    @XmlElement(name = "BoundaryDefinitions")
-    protected TBoundaryDefinitions boundaryDefinitions;
+	@XmlElement(name = "BoundaryDefinitions")
+	protected TBoundaryDefinitions boundaryDefinitions;
 
-    @XmlElement(name = "TopologyTemplate", required = true)
-    protected TTopologyTemplate topologyTemplate;
+	@XmlElement(name = "TopologyTemplate", required = true)
+	protected TTopologyTemplate topologyTemplate;
 
-    @XmlElement(name = "Plans")
-    protected TPlans plans;
+	@XmlElement(name = "Plans")
+	protected TPlans plans;
 
-    @XmlAttribute(name = "name")
-    protected String name;
+	@XmlAttribute(name = "name")
+	protected String name;
 
-    @XmlAttribute(name = "targetNamespace")
-    @XmlSchemaType(name = "anyURI")
-    protected String targetNamespace;
+	@XmlAttribute(name = "targetNamespace")
+	@XmlSchemaType(name = "anyURI")
+	protected String targetNamespace;
 
-    @XmlAttribute(name = "substitutableNodeType")
-    protected QName substitutableNodeType;
+	@XmlAttribute(name = "substitutableNodeType")
+	protected QName substitutableNodeType;
 
-    public TServiceTemplate() {
+	public TServiceTemplate() {
 
-    }
+	}
 
-    public TServiceTemplate(Builder builder) {
-        super(builder);
-        this.tags = builder.tags;
-        this.boundaryDefinitions = builder.boundaryDefinitions;
-        this.topologyTemplate = builder.topologyTemplate;
-        this.plans = builder.plans;
-        this.name = builder.name;
-        this.targetNamespace = builder.targetNamespace;
-        this.substitutableNodeType = builder.substitutableNodeType;
-    }
+	public TServiceTemplate(Builder builder) {
+		super(builder);
+		this.tags = builder.tags;
+		this.boundaryDefinitions = builder.boundaryDefinitions;
+		this.topologyTemplate = builder.topologyTemplate;
+		this.plans = builder.plans;
+		this.name = builder.name;
+		this.targetNamespace = builder.targetNamespace;
+		this.substitutableNodeType = builder.substitutableNodeType;
+	}
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof TServiceTemplate)) return false;
-        if (!super.equals(o)) return false;
-        TServiceTemplate that = (TServiceTemplate) o;
-        return Objects.equals(tags, that.tags) &&
-            Objects.equals(boundaryDefinitions, that.boundaryDefinitions) &&
-            Objects.equals(topologyTemplate, that.topologyTemplate) &&
-            Objects.equals(plans, that.plans) &&
-            Objects.equals(name, that.name) &&
-            Objects.equals(targetNamespace, that.targetNamespace) &&
-            Objects.equals(substitutableNodeType, that.substitutableNodeType);
-    }
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (!(o instanceof TServiceTemplate))
+			return false;
+		if (!super.equals(o))
+			return false;
+		TServiceTemplate that = (TServiceTemplate) o;
+		return Objects.equals(tags, that.tags) && Objects.equals(boundaryDefinitions, that.boundaryDefinitions)
+				&& Objects.equals(topologyTemplate, that.topologyTemplate) && Objects.equals(plans, that.plans)
+				&& Objects.equals(name, that.name) && Objects.equals(targetNamespace, that.targetNamespace)
+				&& Objects.equals(substitutableNodeType, that.substitutableNodeType);
+	}
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), tags, boundaryDefinitions, topologyTemplate, plans, name, targetNamespace, substitutableNodeType);
-    }
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), tags, boundaryDefinitions, topologyTemplate, plans, name, targetNamespace,
+				substitutableNodeType);
+	}
 
-    /**
-     * Gets the value of the tags property.
-     *
-     * @return possible object is {@link TTags }
-     */
-    @Nullable
-    public TTags getTags() {
-        return tags;
-    }
+	/**
+	 * Gets the value of the tags property.
+	 *
+	 * @return possible object is {@link TTags }
+	 */
+	@Nullable
+	public TTags getTags() {
+		return tags;
+	}
 
-    /**
-     * Sets the value of the tags property.
-     *
-     * @param value allowed object is {@link TTags }
-     */
-    public void setTags(TTags value) {
-        this.tags = value;
-    }
+	/**
+	 * Sets the value of the tags property.
+	 *
+	 * @param value
+	 *            allowed object is {@link TTags }
+	 */
+	public void setTags(TTags value) {
+		this.tags = value;
+	}
 
-    /**
-     * Gets the value of the boundaryDefinitions property.
-     *
-     * @return possible object is {@link TBoundaryDefinitions }
-     */
-    @Nullable
-    public TBoundaryDefinitions getBoundaryDefinitions() {
-        return boundaryDefinitions;
-    }
+	/**
+	 * Gets the value of the boundaryDefinitions property.
+	 *
+	 * @return possible object is {@link TBoundaryDefinitions }
+	 */
+	@Nullable
+	public TBoundaryDefinitions getBoundaryDefinitions() {
+		return boundaryDefinitions;
+	}
 
-    /**
-     * Sets the value of the boundaryDefinitions property.
-     *
-     * @param value allowed object is {@link TBoundaryDefinitions }
-     */
-    public void setBoundaryDefinitions(TBoundaryDefinitions value) {
-        this.boundaryDefinitions = value;
-    }
+	/**
+	 * Sets the value of the boundaryDefinitions property.
+	 *
+	 * @param value
+	 *            allowed object is {@link TBoundaryDefinitions }
+	 */
+	public void setBoundaryDefinitions(TBoundaryDefinitions value) {
+		this.boundaryDefinitions = value;
+	}
 
-    /**
-     * Gets the value of the topologyTemplate property.
-     *
-     * @return possible object is {@link TTopologyTemplate }
-     */
-    @NonNull
-    public TTopologyTemplate getTopologyTemplate() {
-        return topologyTemplate;
-    }
+	/**
+	 * Gets the value of the topologyTemplate property.
+	 *
+	 * @return possible object is {@link TTopologyTemplate }
+	 */
+	@NonNull
+	public TTopologyTemplate getTopologyTemplate() {
+		return topologyTemplate;
+	}
 
-    /**
-     * Sets the value of the topologyTemplate property.
-     *
-     * @param value allowed object is {@link TTopologyTemplate }
-     */
-    public void setTopologyTemplate(TTopologyTemplate value) {
-        this.topologyTemplate = value;
-    }
+	/**
+	 * Sets the value of the topologyTemplate property.
+	 *
+	 * @param value
+	 *            allowed object is {@link TTopologyTemplate }
+	 */
+	public void setTopologyTemplate(TTopologyTemplate value) {
+		this.topologyTemplate = value;
+	}
 
-    @Nullable
-    public TPlans getPlans() {
-        return plans;
-    }
+	@Nullable
+	public TPlans getPlans() {
+		return plans;
+	}
 
-    public void setPlans(TPlans value) {
-        this.plans = value;
-    }
+	public void setPlans(TPlans value) {
+		this.plans = value;
+	}
 
-    @Nullable
-    public String getName() {
-        return name;
-    }
+	@Nullable
+	public String getName() {
+		return name;
+	}
 
-    public void setName(String value) {
-        this.name = value;
-    }
+	public void setName(String value) {
+		this.name = value;
+	}
 
-    @Nullable
-    public String getTargetNamespace() {
-        return targetNamespace;
-    }
+	@Nullable
+	public String getTargetNamespace() {
+		return targetNamespace;
+	}
 
-    public void setTargetNamespace(String value) {
-        this.targetNamespace = value;
-    }
+	public void setTargetNamespace(String value) {
+		this.targetNamespace = value;
+	}
 
-    @Nullable
-    public QName getSubstitutableNodeType() {
-        return substitutableNodeType;
-    }
+	@Nullable
+	public QName getSubstitutableNodeType() {
+		return substitutableNodeType;
+	}
 
-    public void setSubstitutableNodeType(QName value) {
-        this.substitutableNodeType = value;
-    }
+	public void setSubstitutableNodeType(QName value) {
+		this.substitutableNodeType = value;
+	}
 
-    public static class Builder extends HasId.Builder<Builder> {
-        private final TTopologyTemplate topologyTemplate;
+	@XmlTransient
+	public String getAbstract() {
+		Map<QName, String> otherAttributes = this.getOtherAttributes();
+		return otherAttributes.get(new QName(Namespaces.TOSCA_WINERY_EXTENSIONS_NAMESPACE, "abstract"));
+	}
 
-        private TTags tags;
-        private TBoundaryDefinitions boundaryDefinitions;
-        private TPlans plans;
-        private String name;
-        private String targetNamespace;
-        private QName substitutableNodeType;
+	public void setAbstract(String value) {
+		Map<QName, String> otherAttributes = this.getOtherAttributes();
+		otherAttributes.put(new QName(Namespaces.TOSCA_WINERY_EXTENSIONS_NAMESPACE, "abstract"), value);
+	}
 
-        public Builder(String id, TTopologyTemplate topologyTemplate) {
-            super(id);
-            this.topologyTemplate = topologyTemplate;
-        }
+	@XmlTransient
+	public String getFinal() {
+		Map<QName, String> otherAttributes = this.getOtherAttributes();
+		return otherAttributes.get(new QName(Namespaces.TOSCA_WINERY_EXTENSIONS_NAMESPACE, "final"));
+	}
 
-        public Builder setTags(TTags tags) {
-            this.tags = tags;
-            return this;
-        }
+	public void setFinal(String value) {
+		Map<QName, String> otherAttributes = this.getOtherAttributes();
+		otherAttributes.put(new QName(Namespaces.TOSCA_WINERY_EXTENSIONS_NAMESPACE, "final"), value);
+	}
 
-        public Builder setBoundaryDefinitions(TBoundaryDefinitions boundaryDefinitions) {
-            this.boundaryDefinitions = boundaryDefinitions;
-            return this;
-        }
+	@XmlTransient
+	public String getDerivedFrom() {
+		Map<QName, String> otherAttributes = this.getOtherAttributes();
+		return otherAttributes.get(new QName(Namespaces.TOSCA_WINERY_EXTENSIONS_NAMESPACE, "derivedFrom"));
+	}
 
-        public Builder setPlans(TPlans plans) {
-            this.plans = plans;
-            return this;
-        }
+	public void setDerivedFrom(String value) {
+		Map<QName, String> otherAttributes = this.getOtherAttributes();
+		otherAttributes.put(new QName(Namespaces.TOSCA_WINERY_EXTENSIONS_NAMESPACE, "derivedFrom"), value);
+	}
 
-        public Builder setName(String name) {
-            this.name = name;
-            return this;
-        }
+	public static class Builder extends HasId.Builder<Builder> {
+		private final TTopologyTemplate topologyTemplate;
 
-        public Builder setTargetNamespace(String targetNamespace) {
-            this.targetNamespace = targetNamespace;
-            return this;
-        }
+		private TTags tags;
+		private TBoundaryDefinitions boundaryDefinitions;
+		private TPlans plans;
+		private String name;
+		private String targetNamespace;
+		private QName substitutableNodeType;
 
-        public Builder setSubstitutableNodeType(QName substitutableNodeType) {
-            this.substitutableNodeType = substitutableNodeType;
-            return this;
-        }
+		public Builder(String id, TTopologyTemplate topologyTemplate) {
+			super(id);
+			this.topologyTemplate = topologyTemplate;
+		}
 
-        public Builder addTags(TTags tags) {
-            if (tags == null || tags.getTag().isEmpty()) {
-                return this;
-            }
+		public Builder setTags(TTags tags) {
+			this.tags = tags;
+			return this;
+		}
 
-            if (this.tags == null) {
-                this.tags = tags;
-            } else {
-                this.tags.getTag().addAll(tags.getTag());
-            }
-            return this;
-        }
+		public Builder setBoundaryDefinitions(TBoundaryDefinitions boundaryDefinitions) {
+			this.boundaryDefinitions = boundaryDefinitions;
+			return this;
+		}
 
-        public Builder addTags(List<TTag> tags) {
-            if (tags == null) {
-                return this;
-            }
+		public Builder setPlans(TPlans plans) {
+			this.plans = plans;
+			return this;
+		}
 
-            TTags tmp = new TTags();
-            tmp.getTag().addAll(tags);
-            return addTags(tmp);
-        }
+		public Builder setName(String name) {
+			this.name = name;
+			return this;
+		}
 
-        public Builder addTags(TTag tags) {
-            if (tags == null) {
-                return this;
-            }
+		public Builder setTargetNamespace(String targetNamespace) {
+			this.targetNamespace = targetNamespace;
+			return this;
+		}
 
-            TTags tmp = new TTags();
-            tmp.getTag().add(tags);
-            return addTags(tmp);
-        }
+		public Builder setSubstitutableNodeType(QName substitutableNodeType) {
+			this.substitutableNodeType = substitutableNodeType;
+			return this;
+		}
 
-        @Override
-        public Builder self() {
-            return this;
-        }
+		public Builder addTags(TTags tags) {
+			if (tags == null || tags.getTag().isEmpty()) {
+				return this;
+			}
 
-        public TServiceTemplate build() {
-            return new TServiceTemplate(this);
-        }
-    }
+			if (this.tags == null) {
+				this.tags = tags;
+			} else {
+				this.tags.getTag().addAll(tags.getTag());
+			}
+			return this;
+		}
+
+		public Builder addTags(List<TTag> tags) {
+			if (tags == null) {
+				return this;
+			}
+
+			TTags tmp = new TTags();
+			tmp.getTag().addAll(tags);
+			return addTags(tmp);
+		}
+
+		public Builder addTags(TTag tags) {
+			if (tags == null) {
+				return this;
+			}
+
+			TTags tmp = new TTags();
+			tmp.getTag().add(tags);
+			return addTags(tmp);
+		}
+
+		@Override
+		public Builder self() {
+			return this;
+		}
+
+		public TServiceTemplate build() {
+			return new TServiceTemplate(this);
+		}
+	}
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/ServiceTemplateResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/ServiceTemplateResource.java
@@ -47,6 +47,7 @@ import org.eclipse.winery.repository.driverspecificationandinjection.DriverInjec
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources._support.AbstractComponentInstanceWithReferencesResource;
 import org.eclipse.winery.repository.rest.resources._support.IHasName;
+import org.eclipse.winery.repository.rest.resources._support.InheritanceResource;
 import org.eclipse.winery.repository.rest.resources._support.dataadapter.injectionadapter.InjectorReplaceData;
 import org.eclipse.winery.repository.rest.resources._support.dataadapter.injectionadapter.InjectorReplaceOptions;
 import org.eclipse.winery.repository.rest.resources.servicetemplates.boundarydefinitions.BoundaryDefinitionsResource;
@@ -280,6 +281,11 @@ public class ServiceTemplateResource extends AbstractComponentInstanceWithRefere
         URI url = uriInfo.getBaseUri().resolve(RestUtils.getAbsoluteURL(id));
         LOGGER.debug("URI of the old and new service template {}", url.toString());
         return Response.created(url).build();
+    }
+    
+    @Path("inheritance/")
+    public InheritanceResource getInheritanceManagement() {
+    		return new InheritanceResource(this);
     }
 
     public TServiceTemplate getServiceTemplate() {

--- a/org.eclipse.winery.repository.ui/src/app/instance/instance.service.ts
+++ b/org.eclipse.winery.repository.ui/src/app/instance/instance.service.ts
@@ -22,106 +22,106 @@ import {ToscaTypes} from '../wineryInterfaces/enums';
 @Injectable()
 export class InstanceService {
 
-    toscaComponent: ToscaComponent;
-    topologyTemplate: WineryTopologyTemplate = null;
-    path: string;
+  toscaComponent: ToscaComponent;
+  topologyTemplate: WineryTopologyTemplate = null;
+  path: string;
 
-    constructor(private http: Http) {
+  constructor(private http: Http) {
+  }
+
+  /**
+   * Get the submenu for the given resource type for displaying a component instance.
+   * TODO: instead of string[], use objects which contain displayName and url fragment
+   *
+   * @returns string[] containing all menus for each resource type.
+   */
+  public getSubMenuByResource(): string[] {
+    let subMenu: string[];
+
+    switch (this.toscaComponent.toscaType) {
+      case ToscaTypes.NodeType:
+        subMenu = ['README', 'LICENSE', 'Visual Appearance', 'Instance States', 'Interfaces', 'Implementations',
+          'Requirement Definitions', 'Capability Definitions', 'Properties Definition',
+          'Inheritance', 'Documentation', 'XML'];
+        break;
+      case ToscaTypes.ServiceTemplate:
+        subMenu = ['README', 'LICENSE', 'Topology Template', 'Plans', 'Selfservice Portal', 'Inheritance',
+          'Boundary Definitions', 'Tags', 'Documentation', 'XML'];
+        break;
+      case ToscaTypes.RelationshipType:
+        subMenu = ['README', 'LICENSE', 'Visual Appearance', 'Instance States', 'Source Interfaces', 'Target Interfaces',
+          'Valid Sources and Targets', 'Implementations', 'Properties Definition',
+          'Inheritance', 'Documentation', 'XML'];
+        break;
+      case ToscaTypes.ArtifactType:
+        subMenu = ['README', 'LICENSE', 'Properties Definition', 'Inheritance', 'Templates', 'Documentation', 'XML'];
+        break;
+      case ToscaTypes.ArtifactTemplate:
+        subMenu = ['README', 'LICENSE', 'Files', 'Source', 'Properties', 'Documentation', 'XML'];
+        break;
+      case ToscaTypes.RequirementType:
+        subMenu = ['README', 'LICENSE', 'Required Capability Type', 'Properties Definition', 'Inheritance', 'Documentation', 'XML'];
+        break;
+      case ToscaTypes.CapabilityType:
+        subMenu = ['README', 'LICENSE', 'Properties Definition', 'Inheritance', 'Documentation', 'XML'];
+        break;
+      case ToscaTypes.NodeTypeImplementation:
+        subMenu = ['README', 'LICENSE', 'Implementation Artifacts', 'Deployment Artifacts', 'Inheritance', 'Documentation', 'XML'];
+        break;
+      case ToscaTypes.RelationshipTypeImplementation:
+        subMenu = ['README', 'LICENSE', 'Implementation Artifacts', 'Inheritance', 'Documentation', 'XML'];
+        break;
+      case ToscaTypes.PolicyType:
+        subMenu = ['README', 'LICENSE', 'Language', 'Applies To', 'Properties Definition', 'Inheritance', 'Templates', 'Documentation', 'XML'];
+        break;
+      case ToscaTypes.PolicyTemplate:
+        subMenu = ['README', 'LICENSE', 'Properties', 'Documentation', 'XML'];
+        break;
+      case ToscaTypes.Imports:
+        subMenu = ['All Declared Elements Local Names', 'All Defined Types Local Names'];
+        break;
+      default: // assume Admin
+        subMenu = ['Namespaces', 'Repository', 'Plan Languages', 'Plan Types', 'Constraint Types', 'Consistency Check', 'Log'];
     }
 
-    /**
-     * Get the submenu for the given resource type for displaying a component instance.
-     * TODO: instead of string[], use objects which contain displayName and url fragment
-     *
-     * @returns string[] containing all menus for each resource type.
-     */
-    public getSubMenuByResource(): string[] {
-        let subMenu: string[];
+    return subMenu;
+  }
 
-        switch (this.toscaComponent.toscaType) {
-            case ToscaTypes.NodeType:
-                subMenu = ['README', 'LICENSE', 'Visual Appearance', 'Instance States', 'Interfaces', 'Implementations',
-                    'Requirement Definitions', 'Capability Definitions', 'Properties Definition',
-                    'Inheritance', 'Documentation', 'XML'];
-                break;
-            case ToscaTypes.ServiceTemplate:
-                subMenu = ['README', 'LICENSE', 'Topology Template', 'Plans', 'Selfservice Portal',
-                    'Boundary Definitions', 'Tags', 'Documentation', 'XML'];
-                break;
-            case ToscaTypes.RelationshipType:
-                subMenu = ['README', 'LICENSE', 'Visual Appearance', 'Instance States', 'Source Interfaces', 'Target Interfaces',
-                    'Valid Sources and Targets', 'Implementations', 'Properties Definition',
-                    'Inheritance', 'Documentation', 'XML'];
-                break;
-            case ToscaTypes.ArtifactType:
-                subMenu = ['README', 'LICENSE', 'Properties Definition', 'Inheritance', 'Templates', 'Documentation', 'XML'];
-                break;
-            case ToscaTypes.ArtifactTemplate:
-                subMenu = ['README', 'LICENSE', 'Files', 'Source', 'Properties', 'Documentation', 'XML'];
-                break;
-            case ToscaTypes.RequirementType:
-                subMenu = ['README', 'LICENSE', 'Required Capability Type', 'Properties Definition', 'Inheritance', 'Documentation', 'XML'];
-                break;
-            case ToscaTypes.CapabilityType:
-                subMenu = ['README', 'LICENSE', 'Properties Definition', 'Inheritance', 'Documentation', 'XML'];
-                break;
-            case ToscaTypes.NodeTypeImplementation:
-                subMenu = ['README', 'LICENSE', 'Implementation Artifacts', 'Deployment Artifacts', 'Inheritance', 'Documentation', 'XML'];
-                break;
-            case ToscaTypes.RelationshipTypeImplementation:
-                subMenu = ['README', 'LICENSE', 'Implementation Artifacts', 'Inheritance', 'Documentation', 'XML'];
-                break;
-            case ToscaTypes.PolicyType:
-                subMenu = ['README', 'LICENSE', 'Language', 'Applies To', 'Properties Definition', 'Inheritance', 'Templates', 'Documentation', 'XML'];
-                break;
-            case ToscaTypes.PolicyTemplate:
-                subMenu = ['README', 'LICENSE', 'Properties', 'Documentation', 'XML'];
-                break;
-            case ToscaTypes.Imports:
-                subMenu = ['All Declared Elements Local Names', 'All Defined Types Local Names'];
-                break;
-            default: // assume Admin
-                subMenu = ['Namespaces', 'Repository', 'Plan Languages', 'Plan Types', 'Constraint Types', 'Consistency Check', 'Log'];
-        }
+  /**
+   * Set the shared data for the children. The path to the actual component is also generated.
+   */
+  public setSharedData(toscaComponent: ToscaComponent): void {
+    this.toscaComponent = toscaComponent;
+    // In order to have always the base path of this instance, create the path here
+    // instead of getting it from the router, because there might be some child routes included.
+    this.path = '/' + this.toscaComponent.toscaType + '/'
+      + encodeURIComponent(encodeURIComponent(this.toscaComponent.namespace)) + '/'
+      + this.toscaComponent.localName;
 
-        return subMenu;
+    if (this.toscaComponent.toscaType === ToscaTypes.ServiceTemplate) {
+      this.getTopologyTemplate()
+        .subscribe(
+        data => this.topologyTemplate = data,
+        error => this.topologyTemplate = null
+        );
     }
+  }
 
-    /**
-     * Set the shared data for the children. The path to the actual component is also generated.
-     */
-    public setSharedData(toscaComponent: ToscaComponent): void {
-        this.toscaComponent = toscaComponent;
-        // In order to have always the base path of this instance, create the path here
-        // instead of getting it from the router, because there might be some child routes included.
-        this.path = '/' + this.toscaComponent.toscaType + '/'
-            + encodeURIComponent(encodeURIComponent(this.toscaComponent.namespace)) + '/'
-            + this.toscaComponent.localName;
+  public deleteComponent(): Observable<any> {
+    return this.http.delete(backendBaseURL + this.path + '/');
+  }
 
-        if (this.toscaComponent.toscaType === ToscaTypes.ServiceTemplate) {
-            this.getTopologyTemplate()
-                .subscribe(
-                    data => this.topologyTemplate = data,
-                    error => this.topologyTemplate = null
-                );
-        }
-    }
+  public getComponentData(): Observable<WineryInstance> {
+    const headers = new Headers({'Accept': 'application/json'});
+    const options = new RequestOptions({headers: headers});
+    return this.http.get(backendBaseURL + this.path + '/', options)
+      .map(res => res.json());
+  }
 
-    public deleteComponent(): Observable<any> {
-        return this.http.delete(backendBaseURL + this.path + '/');
-    }
-
-    public getComponentData(): Observable<WineryInstance> {
-        const headers = new Headers({'Accept': 'application/json'});
-        const options = new RequestOptions({headers: headers});
-        return this.http.get(backendBaseURL + this.path + '/', options)
-            .map(res => res.json());
-    }
-
-    public getTopologyTemplate(): Observable<WineryTopologyTemplate> {
-        const headers = new Headers({'Accept': 'application/json'});
-        const options = new RequestOptions({headers: headers});
-        return this.http.get(backendBaseURL + this.path + '/topologytemplate/', options)
-            .map(res => res.json());
-    }
+  public getTopologyTemplate(): Observable<WineryTopologyTemplate> {
+    const headers = new Headers({'Accept': 'application/json'});
+    const options = new RequestOptions({headers: headers});
+    return this.http.get(backendBaseURL + this.path + '/topologytemplate/', options)
+      .map(res => res.json());
+  }
 }

--- a/org.eclipse.winery.repository.ui/src/app/wineryMainModules/serviceTemplates/serviceTemplateRouter.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryMainModules/serviceTemplates/serviceTemplateRouter.module.ts
@@ -29,6 +29,7 @@ import {DocumentationComponent} from '../../instance/sharedComponents/documentat
 import {ToscaTypes} from '../../wineryInterfaces/enums';
 import {WineryReadmeComponent} from '../../wineryReadmeModule/wineryReadme.component';
 import {WineryLicenseComponent} from '../../wineryLicenseModule/wineryLicense.component';
+import {InheritanceComponent} from '../../instance/sharedComponents/inheritance/inheritance.component';
 
 const toscaType = ToscaTypes.ServiceTemplate;
 
@@ -51,6 +52,7 @@ const serviceTemplateRoutes: Routes = [
                 // 'app/instance/serviceTemplates/selfServicePortal/selfServicePortalRouter.module#SelfServiceRoutingModule'
                 children: selfServiceRoutes
             },
+            {path: 'inheritance', component: InheritanceComponent},
             {
                 path: 'boundarydefinitions',
                 component: BoundaryDefinitionsComponent,


### PR DESCRIPTION
Signed-off-by: Kálmán Képes <kalman.kepes@iaas.uni-stuttgart.de>

Enables setting abstract, derivedFrom and final attributes on Service Templates, just like on NodeTypes. Adds exporting of concrete ServiceTemplates when an abstract Service Template is exported (CSAR may have multiple Service Templates now) 


- Start and end date: <!-- 2017-01-01 to 2017-08-01 -->
- Contributor: Kálmán Képes, @nyuuyn -->

Basically, finished task. Only tweaking remains

![screen shot 2018-02-19 at 15 55 41](https://user-images.githubusercontent.com/2853992/36431911-24935b3e-1659-11e8-9726-eae481f490e5.png)

