### PR TITLE
[WIP] Collapsible Namespace Template

### DIFF
--- a/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.css
+++ b/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.css
@@ -1,0 +1,12 @@
+.collapsespan:after {
+    /* symbol for "opening" panel */
+    font-family: 'Glyphicons Halflings'; /* enable glyphicon */
+    content: "\e260"; /* menu-up glyphicon */
+
+}
+
+.collapsespan.collapsed:after {
+    /* symbol for "collapsed" panels */
+    content: "\e259"; /* menu-down glyphicon */
+}
+

--- a/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.html
+++ b/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.html
@@ -38,18 +38,32 @@
         </div>
     </div>
     <div *ngIf="useStartNamespace" style="margin-top: 20px">
-        <label for="initNamespace" class="control-label">Template: Start of namespace URI - used for automatic
-            namespace URI generation</label>
-        <div style="display: flex;">
-            <input #initNamespace
-                   type="text"
-                   class="form-control"
-                   id="initNamespace"
-                   name="initNamespace"
-                   #namespaceStart="ngModel"
-                   [(ngModel)]="initNamespaceString">
-            <button style="margin-left: 10px; width: 15%;" class="bnt btn-primary" (click)="applyNamespace()">Apply
+        <div>
+            <label for="initNamespace" class="control-label">Template:</label>
+            <button type="button" class="btn btn-default btn-xs collapsebtn"
+                    (click)="isCollapsed = !isCollapsed" style="float: right;">
+                <span class="collapsespan" aria-hidden="true" [class.collapsed]="isCollapsed"></span>
             </button>
+
+        </div>
+        <div (collapsed)="collapsed($event)"
+             (expanded)="expanded($event)"
+             [collapse]="isCollapsed">
+            <div>
+                <label for="initNamespace" class="control-label">Start of namespace URI - used for automatic
+                    namespace URI generation</label>
+            </div>
+            <div style="display: flex;">
+                <input #initNamespace
+                       type="text"
+                       class="form-control"
+                       id="initNamespace"
+                       name="initNamespace"
+                       #namespaceStart="ngModel"
+                       [(ngModel)]="initNamespaceString">
+                <button style="margin-left: 10px; width: 15%;" class="bnt btn-primary" (click)="applyNamespace()">Apply
+                </button>
+            </div>
         </div>
         <div *ngIf="namespaceStart.errors && (namespaceStart.dirty || namespaceStart.touched)"
              class="alert alert-danger">

--- a/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.ts
@@ -67,6 +67,7 @@ const customInputControl: any = {
 @Component({
     selector: 'winery-namespace-selector',
     templateUrl: './wineryNamespaceSelector.component.html',
+    styleUrls: ['./wineryNamespaceSelector.component.css'],
     providers: [
         WineryNamespaceSelectorService,
         customInputControl
@@ -80,6 +81,7 @@ export class WineryNamespaceSelectorComponent implements OnInit, ControlValueAcc
     @Input() useStartNamespace = true;
 
     loading = true;
+    isCollapsed = true;
     allNamespaces: NamespaceWithPrefix[] = [];
 
     @ViewChild('namespaceInput') namespaceInput: ElementRef;
@@ -146,6 +148,12 @@ export class WineryNamespaceSelectorComponent implements OnInit, ControlValueAcc
 
     registerOnTouched(fn: any) {
         this.onTouchedCallback = fn;
+    }
+
+    collapsed(event: any): void {
+    }
+
+    expanded(event: any): void {
     }
 
     // endregion

--- a/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.module.ts
+++ b/org.eclipse.winery.repository.ui/src/app/wineryNamespaceSelector/wineryNamespaceSelector.module.ts
@@ -15,7 +15,7 @@ import {NgModule} from '@angular/core';
 
 import {FormsModule} from '@angular/forms';
 import {BrowserModule} from '@angular/platform-browser';
-import {TypeaheadModule} from 'ngx-bootstrap';
+import {CollapseModule, TypeaheadModule} from 'ngx-bootstrap';
 import {ToastModule} from 'ng2-toastr';
 import {WineryLoaderModule} from '../wineryLoader/wineryLoader.module';
 import {WineryNamespaceSelectorComponent} from './wineryNamespaceSelector.component';
@@ -27,6 +27,7 @@ import {WineryNamespaceSelectorComponent} from './wineryNamespaceSelector.compon
         TypeaheadModule,
         WineryLoaderModule,
         ToastModule.forRoot(),
+        CollapseModule.forRoot()
     ],
     exports: [WineryNamespaceSelectorComponent],
     declarations: [WineryNamespaceSelectorComponent],


### PR DESCRIPTION


The goal is to make the template for namespaces in the 'add new' modal for a service template, artifact template, etc.  collapsible.

- Start and end date: <!-- 2017-23-03 to ongoing -->
- Contributor: Tino Stadelmaier, @TStadelmaier
- Supervisor: Oliver Kopp, @koppor, Christoph Kleine, @kleinech 

Add funtionality to expand and collapse the template for namespaces.

Screenshots:
![template collapsed](https://user-images.githubusercontent.com/23086006/37879927-c4c44e06-3080-11e8-8e0f-7c9d524b79e1.png)
![template-expanded](https://user-images.githubusercontent.com/23086006/37879929-c8c53182-3080-11e8-9f12-bcc4125f4dee.png)

