### PR TITLE
Fix/display of properties

### DIFF
--- a/LICENSE.spdx
+++ b/LICENSE.spdx
@@ -1,0 +1,5 @@
+SPDXVersion: SPDX-2.1
+PackageName: Eclipse Winery
+PackageOriginator: Eclipse Foundation
+PackageHomePage: https://github.com/ecipse/winery
+PackageLicenseDeclared: Apache-2.0 OR EPL-2.0

--- a/docs/dev/ToolChain-initialization.md
+++ b/docs/dev/ToolChain-initialization.md
@@ -12,13 +12,15 @@ Email your supervisor your GitHub username.
   Example: `flastname@gmail.com`.
 - Please enable the git-hooks by executing `git config core.hooksPath .git-hooks` in the root of the repository.
 
-## Development enviroment installation steps
+## Steps to get Apache Maven ready
 
-1. Get [Apache Maven](https://maven.apache.org/) to run
-    1. Get [choclatey](https://chocolatey.org/)
-    1. Execute in an **Administor cmd.exe**: `@"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"`
-    1. Execute `choco install maven`. This also installs the latest Java8 JDK.
-1. Setup IntelliJ as described at [config/IntelliJ IDEA](config/IntelliJ%20IDEA).
+Get [Apache Maven](https://maven.apache.org/) to run.
+
+Windows:
+
+1. Get [choclatey](https://chocolatey.org/)
+1. Execute in an **Administor cmd.exe**: `@"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"`
+1. Execute `choco install maven`. This also installs the latest Java8 JDK.
 
 ## Steps to get write access to the code repositories
 
@@ -30,18 +32,25 @@ Email your supervisor your GitHub username.
 
 ## Steps to initialize the code repository
 
-  1. Clone <https://github.com/opentosca/winery> (it automatically becomes the `origin`).
-     - We recommend that git repositories reside in `c:\git-repositories`.
-     - Use [ConEmu](https://conemu.github.io/) as program for all your shells: `choco install conemu`.
-       Install [chocolatey](https://chocolatey.org/) to use the `choco` command.
-     - Execute `git clone https://github.com/OpenTOSCA/winery.git` in `c:\git-repositories`.
-  2. Change into the newly created directory `winery`: `cd winery`.
-  3. Add `upstream` as second remote: `git remote add upstream https://github.com/eclipse/winery.git`
-  4. Fetch everything from `upstream`: `git fetch upstream`
+1. Clone <https://github.com/opentosca/winery> (it automatically becomes the `origin`).
+   - We recommend that git repositories reside in `c:\git-repositories`.
+   - Use [ConEmu](https://conemu.github.io/) as program for all your shells: `choco install conemu`.
+     Install [chocolatey](https://chocolatey.org/) to use the `choco` command.
+   - Execute `git clone https://github.com/OpenTOSCA/winery.git` in `c:\git-repositories`.
+2. Change into the newly created directory `winery`: `cd winery`.
+3. Add `upstream` as second remote: `git remote add upstream https://github.com/eclipse/winery.git`
+4. Fetch everything from `upstream`: `git fetch upstream`
+5. Run `mvn package` to have `Version.java` generated
 
 ## Steps to initialize the TOSCA repository
 
 Please go to the [quick start guide](../user/quickstart.md).
+
+## Steps to initialize the IDE
+
+Setup IntelliJ as described at [config/IntelliJ IDEA](config/IntelliJ%20IDEA).
+Alternatively, you can you Eclipse as described at [config/Eclipse](config/Eclipse).
+However, the latter is currently work-in-progress.
 
 ## License
 

--- a/docs/dev/ToolChain-initialization.md
+++ b/docs/dev/ToolChain-initialization.md
@@ -40,7 +40,7 @@ Windows:
 2. Change into the newly created directory `winery`: `cd winery`.
 3. Add `upstream` as second remote: `git remote add upstream https://github.com/eclipse/winery.git`
 4. Fetch everything from `upstream`: `git fetch upstream`
-5. Run `mvn package` to have `Version.java` generated
+5. Run `mvn package -DskipTests` to have `Version.java` generated
 
 ## Steps to initialize the TOSCA repository
 

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TArtifactTemplate.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TArtifactTemplate.java
@@ -14,46 +14,21 @@
 
 package org.eclipse.winery.model.tosca;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
 
-/**
- * <p>Java class for tArtifactTemplate complex type.
- * <p>
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;complexType name="tArtifactTemplate">
- *   &lt;complexContent>
- *     &lt;extension base="{http://docs.oasis-open.org/tosca/ns/2011/12}tEntityTemplate">
- *       &lt;sequence>
- *         &lt;element name="ArtifactReferences" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;sequence>
- *                   &lt;element name="ArtifactReference" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tArtifactReference"
- * maxOccurs="unbounded"/>
- *                 &lt;/sequence>
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *       &lt;/sequence>
- *       &lt;attribute name="name" type="{http://www.w3.org/2001/XMLSchema}string" />
- *       &lt;anyAttribute processContents='lax' namespace='##other'/>
- *     &lt;/extension>
- *   &lt;/complexContent>
- * &lt;/complexType>
- * </pre>
- */
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tArtifactTemplate", propOrder = {
     "artifactReferences"
@@ -95,8 +70,7 @@ public class TArtifactTemplate
      *
      * @return possible object is {@link TArtifactTemplate.ArtifactReferences }
      */
-    /*@Nullable*/
-    public TArtifactTemplate.ArtifactReferences getArtifactReferences() {
+    public TArtifactTemplate.@Nullable ArtifactReferences getArtifactReferences() {
 
         return artifactReferences;
     }
@@ -130,24 +104,6 @@ public class TArtifactTemplate
     }
 
 
-    /**
-     * <p>Java class for anonymous complex type.
-     * <p>
-     * <p>The following schema fragment specifies the expected content contained within this class.
-     * <p>
-     * <pre>
-     * &lt;complexType>
-     *   &lt;complexContent>
-     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
-     *       &lt;sequence>
-     *         &lt;element name="ArtifactReference" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tArtifactReference"
-     * maxOccurs="unbounded"/>
-     *       &lt;/sequence>
-     *     &lt;/restriction>
-     *   &lt;/complexContent>
-     * &lt;/complexType>
-     * </pre>
-     */
     @XmlAccessorType(XmlAccessType.FIELD)
     @XmlType(name = "", propOrder = {
         "artifactReference"
@@ -171,11 +127,6 @@ public class TArtifactTemplate
          * <pre>
          *    getArtifactReference().add(newItem);
          * </pre>
-         * <p>
-         * <p>
-         * <p>
-         * Objects of the following type(s) are allowed in the list
-         * {@link TArtifactReference }
          */
         @NonNull
         public List<TArtifactReference> getArtifactReference() {

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TBoundaryDefinitions.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TBoundaryDefinitions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,114 +14,20 @@
 
 package org.eclipse.winery.model.tosca;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
-
-import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
 
-/**
- * <p>Java class for tBoundaryDefinitions complex type.
- * <p>
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;complexType name="tBoundaryDefinitions">
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element name="Properties" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;sequence>
- *                   &lt;any namespace='##other'/>
- *                   &lt;element name="PropertyMappings" minOccurs="0">
- *                     &lt;complexType>
- *                       &lt;complexContent>
- *                         &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                           &lt;sequence>
- *                             &lt;element name="PropertyMapping" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tPropertyMapping"
- * maxOccurs="unbounded"/>
- *                           &lt;/sequence>
- *                         &lt;/restriction>
- *                       &lt;/complexContent>
- *                     &lt;/complexType>
- *                   &lt;/element>
- *                 &lt;/sequence>
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *         &lt;element name="PropertyConstraints" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;sequence>
- *                   &lt;element name="PropertyConstraint" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tPropertyConstraint"
- * maxOccurs="unbounded"/>
- *                 &lt;/sequence>
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *         &lt;element name="Requirements" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;sequence>
- *                   &lt;element name="Requirement" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tRequirementRef"
- * maxOccurs="unbounded"/>
- *                 &lt;/sequence>
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *         &lt;element name="Capabilities" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;sequence>
- *                   &lt;element name="Capability" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tCapabilityRef"
- * maxOccurs="unbounded"/>
- *                 &lt;/sequence>
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *         &lt;element name="Policies" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;sequence>
- *                   &lt;element name="Policy" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tPolicy"
- * maxOccurs="unbounded"/>
- *                 &lt;/sequence>
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *         &lt;element name="Interfaces" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;sequence>
- *                   &lt;element name="Interface" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tExportedInterface"
- * maxOccurs="unbounded"/>
- *                 &lt;/sequence>
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *       &lt;/sequence>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
- * </pre>
- */
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tBoundaryDefinitions", propOrder = {
     "properties",
@@ -181,8 +87,7 @@ public class TBoundaryDefinitions {
      *
      * @return possible object is {@link TBoundaryDefinitions.Properties }
      */
-    /*@Nullable*/
-    public TBoundaryDefinitions.Properties getProperties() {
+    public TBoundaryDefinitions.@Nullable Properties getProperties() {
         return properties;
     }
 
@@ -200,8 +105,7 @@ public class TBoundaryDefinitions {
      *
      * @return possible object is {@link TBoundaryDefinitions.PropertyConstraints }
      */
-    /*@Nullable*/
-    public TBoundaryDefinitions.PropertyConstraints getPropertyConstraints() {
+    public TBoundaryDefinitions.@Nullable PropertyConstraints getPropertyConstraints() {
         return propertyConstraints;
     }
 
@@ -219,8 +123,7 @@ public class TBoundaryDefinitions {
      *
      * @return possible object is {@link TBoundaryDefinitions.Requirements }
      */
-    /*@Nullable*/
-    public TBoundaryDefinitions.Requirements getRequirements() {
+    public TBoundaryDefinitions.@Nullable Requirements getRequirements() {
         return requirements;
     }
 
@@ -238,8 +141,7 @@ public class TBoundaryDefinitions {
      *
      * @return possible object is {@link TBoundaryDefinitions.Capabilities }
      */
-    /*@Nullable*/
-    public TBoundaryDefinitions.Capabilities getCapabilities() {
+    public TBoundaryDefinitions.@Nullable Capabilities getCapabilities() {
         return capabilities;
     }
 
@@ -257,8 +159,7 @@ public class TBoundaryDefinitions {
      *
      * @return possible object is {@link TBoundaryDefinitions.Policies }
      */
-    /*@Nullable*/
-    public TBoundaryDefinitions.Policies getPolicies() {
+    public TBoundaryDefinitions.@Nullable Policies getPolicies() {
         return policies;
     }
 
@@ -276,8 +177,7 @@ public class TBoundaryDefinitions {
      *
      * @return possible object is {@link TBoundaryDefinitions.Interfaces }
      */
-    /*@Nullable*/
-    public TBoundaryDefinitions.Interfaces getInterfaces() {
+    public TBoundaryDefinitions.@Nullable Interfaces getInterfaces() {
         return interfaces;
     }
 
@@ -527,8 +427,7 @@ public class TBoundaryDefinitions {
          *
          * @return possible object is {@link TBoundaryDefinitions.Properties.PropertyMappings }
          */
-        /*@Nullable*/
-        public TBoundaryDefinitions.Properties.PropertyMappings getPropertyMappings() {
+        public TBoundaryDefinitions.Properties.@Nullable PropertyMappings getPropertyMappings() {
             return propertyMappings;
         }
 
@@ -589,7 +488,7 @@ public class TBoundaryDefinitions {
              * Objects of the following type(s) are allowed in the list
              * {@link TPropertyMapping }
              */
-            /*@Nullable*/
+            @Nullable
             public List<TPropertyMapping> getPropertyMapping() {
                 if (propertyMapping == null) {
                     propertyMapping = new ArrayList<TPropertyMapping>();

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TCapabilityDefinition.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TCapabilityDefinition.java
@@ -14,64 +14,21 @@
 
 package org.eclipse.winery.model.tosca;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
 
-/**
- * <p>Java class for tCapabilityDefinition complex type.
- * <p>
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;complexType name="tCapabilityDefinition">
- *   &lt;complexContent>
- *     &lt;extension base="{http://docs.oasis-open.org/tosca/ns/2011/12}tExtensibleElements">
- *       &lt;sequence>
- *         &lt;element name="Constraints" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;sequence>
- *                   &lt;element name="Constraint" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tConstraint"
- * maxOccurs="unbounded"/>
- *                 &lt;/sequence>
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *       &lt;/sequence>
- *       &lt;attribute name="name" use="required" type="{http://www.w3.org/2001/XMLSchema}string" />
- *       &lt;attribute name="capabilityType" use="required" type="{http://www.w3.org/2001/XMLSchema}QName" />
- *       &lt;attribute name="lowerBound" type="{http://www.w3.org/2001/XMLSchema}int" default="1" />
- *       &lt;attribute name="upperBound" default="1">
- *         &lt;simpleType>
- *           &lt;union>
- *             &lt;simpleType>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}nonNegativeInteger">
- *                 &lt;pattern value="([1-9]+[0-9]*)"/>
- *               &lt;/restriction>
- *             &lt;/simpleType>
- *             &lt;simpleType>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
- *                 &lt;enumeration value="unbounded"/>
- *               &lt;/restriction>
- *             &lt;/simpleType>
- *           &lt;/union>
- *         &lt;/simpleType>
- *       &lt;/attribute>
- *       &lt;anyAttribute processContents='lax' namespace='##other'/>
- *     &lt;/extension>
- *   &lt;/complexContent>
- * &lt;/complexType>
- * </pre>
- */
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tCapabilityDefinition", propOrder = {
     "constraints"
@@ -122,8 +79,7 @@ public class TCapabilityDefinition extends TExtensibleElements {
      *
      * @return possible object is {@link TCapabilityDefinition.Constraints }
      */
-    /*@Nullable*/
-    public TCapabilityDefinition.Constraints getConstraints() {
+    public TCapabilityDefinition.@Nullable Constraints getConstraints() {
         return constraints;
     }
 

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TDefinitions.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TDefinitions.java
@@ -14,18 +14,28 @@
 
 package org.eclipse.winery.model.tosca;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.github.adr.embedded.ADR;
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
-import org.w3c.dom.Element;
-
-import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlType;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.github.adr.embedded.ADR;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.w3c.dom.Element;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tDefinitions", propOrder = {
@@ -115,8 +125,7 @@ public class TDefinitions extends HasId implements HasName, HasTargetNamespace {
         this.getServiceTemplateOrNodeTypeOrNodeTypeImplementation().add(element);
     }
 
-    /*@Nullable*/
-    public TDefinitions.Extensions getExtensions() {
+    public TDefinitions.@Nullable Extensions getExtensions() {
         return extensions;
     }
 
@@ -152,8 +161,7 @@ public class TDefinitions extends HasId implements HasName, HasTargetNamespace {
         return this._import;
     }
 
-    /*@Nullable*/
-    public TDefinitions.Types getTypes() {
+    public TDefinitions.@Nullable Types getTypes() {
         return types;
     }
 

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TEntityTemplate.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TEntityTemplate.java
@@ -14,22 +14,39 @@
 
 package org.eclipse.winery.model.tosca;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.eclipse.winery.model.tosca.constants.Namespaces;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.github.adr.embedded.ADR;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.winery.model.tosca.constants.Namespaces;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.*;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import java.util.*;
+import org.w3c.dom.Comment;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Text;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tEntityTemplate", propOrder = {
@@ -89,8 +106,7 @@ public abstract class TEntityTemplate extends HasId implements HasType, HasName 
         return Objects.hash(super.hashCode(), properties, propertyConstraints, type);
     }
 
-    /*@Nullable*/
-    public TEntityTemplate.Properties getProperties() {
+    public TEntityTemplate.@Nullable Properties getProperties() {
         return properties;
     }
 
@@ -98,8 +114,7 @@ public abstract class TEntityTemplate extends HasId implements HasType, HasName 
         this.properties = value;
     }
 
-    /*@Nullable*/
-    public TEntityTemplate.PropertyConstraints getPropertyConstraints() {
+    public TEntityTemplate.@Nullable PropertyConstraints getPropertyConstraints() {
         return propertyConstraints;
     }
 

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TEntityType.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TEntityType.java
@@ -14,61 +14,29 @@
 
 package org.eclipse.winery.model.tosca;
 
+import java.util.List;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import javax.xml.namespace.QName;
+
+import org.eclipse.winery.model.tosca.kvproperties.WinerysPropertiesDefinition;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.github.adr.embedded.ADR;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.winery.model.tosca.kvproperties.WinerysPropertiesDefinition;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import javax.xml.namespace.QName;
-import java.util.List;
-import java.util.Objects;
 
 
-/**
- * <p>Java class for tEntityType complex type.
- * <p>
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;complexType name="tEntityType">
- *   &lt;complexContent>
- *     &lt;extension base="{http://docs.oasis-open.org/tosca/ns/2011/12}tExtensibleElements">
- *       &lt;sequence>
- *         &lt;element name="Tags" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tTags" minOccurs="0"/>
- *         &lt;element name="DerivedFrom" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;attribute name="typeRef" use="required" type="{http://www.w3.org/2001/XMLSchema}QName" />
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *         &lt;element name="PropertiesDefinition" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;attribute name="element" type="{http://www.w3.org/2001/XMLSchema}QName" />
- *                 &lt;attribute name="type" type="{http://www.w3.org/2001/XMLSchema}QName" />
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *       &lt;/sequence>
- *       &lt;attribute name="name" use="required" type="{http://www.w3.org/2001/XMLSchema}NCName" />
- *       &lt;attribute name="abstract" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tBoolean" default="no" />
- *       &lt;attribute name="final" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tBoolean" default="no" />
- *       &lt;attribute name="targetNamespace" type="{http://www.w3.org/2001/XMLSchema}anyURI" />
- *       &lt;anyAttribute processContents='lax' namespace='##other'/>
- *     &lt;/extension>
- *   &lt;/complexContent>
- * &lt;/complexType>
- * </pre>
- */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tEntityType", propOrder = {
     "tags",
@@ -159,8 +127,7 @@ public class TEntityType extends TExtensibleElements implements HasName, HasInhe
      *
      * @return possible object is {@link TEntityType.DerivedFrom }
      */
-    /*@Nullable*/
-    public TEntityType.DerivedFrom getDerivedFrom() {
+    public TEntityType.@Nullable DerivedFrom getDerivedFrom() {
         return derivedFrom;
     }
 
@@ -178,8 +145,7 @@ public class TEntityType extends TExtensibleElements implements HasName, HasInhe
      *
      * @return possible object is {@link TEntityType.PropertiesDefinition }
      */
-    /*@Nullable*/
-    public TEntityType.PropertiesDefinition getPropertiesDefinition() {
+    public TEntityType.@Nullable PropertiesDefinition getPropertiesDefinition() {
         return propertiesDefinition;
     }
 

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TExportedOperation.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TExportedOperation.java
@@ -14,65 +14,24 @@
 
 package org.eclipse.winery.model.tosca;
 
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlIDREF;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.eclipse.jdt.annotation.NonNull;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import java.util.Objects;
+import org.eclipse.jdt.annotation.Nullable;
 
 
-/**
- * <p>Java class for tExportedOperation complex type.
- * <p>
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;complexType name="tExportedOperation">
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;choice>
- *         &lt;element name="NodeOperation">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;attribute name="nodeRef" use="required" type="{http://www.w3.org/2001/XMLSchema}IDREF" />
- *                 &lt;attribute name="interfaceName" use="required" type="{http://www.w3.org/2001/XMLSchema}anyURI" />
- *                 &lt;attribute name="operationName" use="required" type="{http://www.w3.org/2001/XMLSchema}NCName" />
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *         &lt;element name="RelationshipOperation">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;attribute name="relationshipRef" use="required" type="{http://www.w3.org/2001/XMLSchema}IDREF"
- * />
- *                 &lt;attribute name="interfaceName" use="required" type="{http://www.w3.org/2001/XMLSchema}anyURI" />
- *                 &lt;attribute name="operationName" use="required" type="{http://www.w3.org/2001/XMLSchema}NCName" />
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *         &lt;element name="Plan">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;attribute name="planRef" use="required" type="{http://www.w3.org/2001/XMLSchema}IDREF" />
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *       &lt;/choice>
- *       &lt;attribute name="name" use="required" type="{http://www.w3.org/2001/XMLSchema}NCName" />
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
- * </pre>
- */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tExportedOperation", propOrder = {
     "nodeOperation",
@@ -114,8 +73,7 @@ public class TExportedOperation implements HasName {
      *
      * @return possible object is {@link TExportedOperation.NodeOperation }
      */
-    /*@Nullable*/
-    public TExportedOperation.NodeOperation getNodeOperation() {
+    public TExportedOperation.@Nullable NodeOperation getNodeOperation() {
         return nodeOperation;
     }
 
@@ -133,8 +91,7 @@ public class TExportedOperation implements HasName {
      *
      * @return possible object is {@link TExportedOperation.RelationshipOperation }
      */
-    /*@Nullable*/
-    public TExportedOperation.RelationshipOperation getRelationshipOperation() {
+    public TExportedOperation.@Nullable RelationshipOperation getRelationshipOperation() {
         return relationshipOperation;
     }
 
@@ -152,8 +109,7 @@ public class TExportedOperation implements HasName {
      *
      * @return possible object is {@link TExportedOperation.Plan }
      */
-    /*@Nullable*/
-    public TExportedOperation.Plan getPlan() {
+    public TExportedOperation.@Nullable Plan getPlan() {
         return plan;
     }
 

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TExtensibleElements.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TExtensibleElements.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,37 +14,27 @@
 
 package org.eclipse.winery.model.tosca;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyAttribute;
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.github.adr.embedded.ADR;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
-import org.w3c.dom.Element;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
-import java.util.*;
 
 
-/**
- * <p>Java class for tExtensibleElements complex type.
- * <p>
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;complexType name="tExtensibleElements">
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;sequence>
- *         &lt;element ref="{http://docs.oasis-open.org/tosca/ns/2011/12}documentation" maxOccurs="unbounded"
- * minOccurs="0"/>
- *         &lt;any processContents='lax' namespace='##other' maxOccurs="unbounded" minOccurs="0"/>
- *       &lt;/sequence>
- *       &lt;anyAttribute processContents='lax' namespace='##other'/>
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
- * </pre>
- */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tExtensibleElements", propOrder = {
     "documentation",
@@ -115,11 +105,6 @@ public class TExtensibleElements {
      * <pre>
      *    getDocumentation().add(newItem);
      * </pre>
-     * <p>
-     * <p>
-     * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link TDocumentation }
      */
     @NonNull
     public List<TDocumentation> getDocumentation() {
@@ -137,18 +122,6 @@ public class TExtensibleElements {
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the any property.
-     * <p>
-     * <p>
-     * For example, to add a new item, do as follows:
-     * <pre>
-     *    getAny().add(newItem);
-     * </pre>
-     * <p>
-     * <p>
-     * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link Element }
-     * {@link Object }
      */
     @NonNull
     public List<Object> getAny() {

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TNodeTemplate.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TNodeTemplate.java
@@ -14,18 +14,25 @@
 
 package org.eclipse.winery.model.tosca;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.winery.model.tosca.constants.Namespaces;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
+
+import org.eclipse.winery.model.tosca.constants.Namespaces;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tNodeTemplate", propOrder = {
@@ -118,8 +125,7 @@ public class TNodeTemplate extends RelationshipSourceOrTarget {
         this.capabilities = value;
     }
 
-    /*@Nullable*/
-    public TNodeTemplate.Policies getPolicies() {
+    public TNodeTemplate.@Nullable Policies getPolicies() {
         return policies;
     }
 

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TNodeType.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TNodeType.java
@@ -14,15 +14,17 @@
 
 package org.eclipse.winery.model.tosca;
 
-import org.eclipse.jdt.annotation.NonNull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tNodeType", propOrder = {
@@ -69,8 +71,7 @@ public class TNodeType extends TEntityType {
         return Objects.hash(super.hashCode(), requirementDefinitions, capabilityDefinitions, instanceStates, interfaces);
     }
 
-    /*@Nullable*/
-    public TNodeType.RequirementDefinitions getRequirementDefinitions() {
+    public TNodeType.@Nullable RequirementDefinitions getRequirementDefinitions() {
         return requirementDefinitions;
     }
 
@@ -78,8 +79,7 @@ public class TNodeType extends TEntityType {
         this.requirementDefinitions = value;
     }
 
-    /*@Nullable*/
-    public TNodeType.CapabilityDefinitions getCapabilityDefinitions() {
+    public TNodeType.@Nullable CapabilityDefinitions getCapabilityDefinitions() {
         return capabilityDefinitions;
     }
 
@@ -87,7 +87,7 @@ public class TNodeType extends TEntityType {
         this.capabilityDefinitions = value;
     }
 
-    /*@Nullable*/
+    @Nullable
     public TTopologyElementInstanceStates getInstanceStates() {
         return instanceStates;
     }
@@ -96,8 +96,7 @@ public class TNodeType extends TEntityType {
         this.instanceStates = value;
     }
 
-    /*@Nullable*/
-    public TNodeType.Interfaces getInterfaces() {
+    public TNodeType.@Nullable Interfaces getInterfaces() {
         return interfaces;
     }
 

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TOperation.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TOperation.java
@@ -14,58 +14,23 @@
 
 package org.eclipse.winery.model.tosca;
 
-import org.eclipse.jdt.annotation.NonNull;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-/**
- * <p>Java class for tOperation complex type.
- * <p>
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;complexType name="tOperation">
- *   &lt;complexContent>
- *     &lt;extension base="{http://docs.oasis-open.org/tosca/ns/2011/12}tExtensibleElements">
- *       &lt;sequence>
- *         &lt;element name="InputParameters" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;sequence>
- *                   &lt;element name="InputParameter" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tParameter"
- * maxOccurs="unbounded"/>
- *                 &lt;/sequence>
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *         &lt;element name="OutputParameters" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;sequence>
- *                   &lt;element name="OutputParameter" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tParameter"
- * maxOccurs="unbounded"/>
- *                 &lt;/sequence>
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *       &lt;/sequence>
- *       &lt;attribute name="name" use="required" type="{http://www.w3.org/2001/XMLSchema}NCName" />
- *       &lt;anyAttribute processContents='lax' namespace='##other'/>
- *     &lt;/extension>
- *   &lt;/complexContent>
- * &lt;/complexType>
- * </pre>
- */
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tOperation", propOrder = {
     "inputParameters",
@@ -112,8 +77,7 @@ public class TOperation extends TExtensibleElements {
      *
      * @return possible object is {@link TOperation.InputParameters }
      */
-    /*@Nullable*/
-    public TOperation.InputParameters getInputParameters() {
+    public TOperation.@Nullable InputParameters getInputParameters() {
         return inputParameters;
     }
 
@@ -131,8 +95,7 @@ public class TOperation extends TExtensibleElements {
      *
      * @return possible object is {@link TOperation.OutputParameters }
      */
-    /*@Nullable*/
-    public TOperation.OutputParameters getOutputParameters() {
+    public TOperation.@Nullable OutputParameters getOutputParameters() {
         return outputParameters;
     }
 

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TPlan.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TPlan.java
@@ -14,89 +14,28 @@
 
 package org.eclipse.winery.model.tosca;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlID;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.w3c.dom.Element;
 
-import javax.xml.bind.annotation.*;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
 
-
-/**
- * <p>Java class for tPlan complex type.
- * <p>
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;complexType name="tPlan">
- *   &lt;complexContent>
- *     &lt;extension base="{http://docs.oasis-open.org/tosca/ns/2011/12}tExtensibleElements">
- *       &lt;sequence>
- *         &lt;element name="Precondition" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tCondition"
- * minOccurs="0"/>
- *         &lt;element name="InputParameters" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;sequence>
- *                   &lt;element name="InputParameter" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tParameter"
- * maxOccurs="unbounded"/>
- *                 &lt;/sequence>
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *         &lt;element name="OutputParameters" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;sequence>
- *                   &lt;element name="OutputParameter" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tParameter"
- * maxOccurs="unbounded"/>
- *                 &lt;/sequence>
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *         &lt;choice>
- *           &lt;element name="PlanModel">
- *             &lt;complexType>
- *               &lt;complexContent>
- *                 &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                   &lt;sequence>
- *                     &lt;any processContents='lax' namespace='##other'/>
- *                   &lt;/sequence>
- *                 &lt;/restriction>
- *               &lt;/complexContent>
- *             &lt;/complexType>
- *           &lt;/element>
- *           &lt;element name="PlanModelReference">
- *             &lt;complexType>
- *               &lt;complexContent>
- *                 &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                   &lt;attribute name="reference" use="required" type="{http://www.w3.org/2001/XMLSchema}anyURI" />
- *                 &lt;/restriction>
- *               &lt;/complexContent>
- *             &lt;/complexType>
- *           &lt;/element>
- *         &lt;/choice>
- *       &lt;/sequence>
- *       &lt;attribute name="id" use="required" type="{http://www.w3.org/2001/XMLSchema}ID" />
- *       &lt;attribute name="name" type="{http://www.w3.org/2001/XMLSchema}string" />
- *       &lt;attribute name="planType" use="required" type="{http://www.w3.org/2001/XMLSchema}anyURI" />
- *       &lt;attribute name="planLanguage" use="required" type="{http://www.w3.org/2001/XMLSchema}anyURI" />
- *       &lt;anyAttribute processContents='lax' namespace='##other'/>
- *     &lt;/extension>
- *   &lt;/complexContent>
- * &lt;/complexType>
- * </pre>
- */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tPlan", propOrder = {
     "precondition",
@@ -194,8 +133,7 @@ public class TPlan extends TExtensibleElements {
      *
      * @return possible object is {@link TPlan.InputParameters }
      */
-    /*@Nullable*/
-    public TPlan.InputParameters getInputParameters() {
+    public TPlan.@Nullable InputParameters getInputParameters() {
         return inputParameters;
     }
 
@@ -213,8 +151,7 @@ public class TPlan extends TExtensibleElements {
      *
      * @return possible object is {@link TPlan.OutputParameters }
      */
-    /*@Nullable*/
-    public TPlan.OutputParameters getOutputParameters() {
+    public TPlan.@Nullable OutputParameters getOutputParameters() {
         return outputParameters;
     }
 
@@ -232,8 +169,7 @@ public class TPlan extends TExtensibleElements {
      *
      * @return possible object is {@link TPlan.PlanModel }
      */
-    /*@Nullable*/
-    public TPlan.PlanModel getPlanModel() {
+    public TPlan.@Nullable PlanModel getPlanModel() {
         return planModel;
     }
 
@@ -251,8 +187,7 @@ public class TPlan extends TExtensibleElements {
      *
      * @return possible object is {@link TPlan.PlanModelReference }
      */
-    /*@Nullable*/
-    public TPlan.PlanModelReference getPlanModelReference() {
+    public TPlan.@Nullable PlanModelReference getPlanModelReference() {
         return planModelReference;
     }
 

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TRelationshipTemplate.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TRelationshipTemplate.java
@@ -115,8 +115,7 @@ public class TRelationshipTemplate extends TEntityTemplate {
      *
      * @return possible object is {@link TRelationshipTemplate.RelationshipConstraints }
      */
-    /*@Nullable*/
-    public TRelationshipTemplate.RelationshipConstraints getRelationshipConstraints() {
+    public TRelationshipTemplate.@Nullable RelationshipConstraints getRelationshipConstraints() {
         return relationshipConstraints;
     }
 
@@ -149,35 +148,6 @@ public class TRelationshipTemplate extends TEntityTemplate {
     }
 
 
-    /**
-     * <p>Java class for anonymous complex type.
-     * <p>
-     * <p>The following schema fragment specifies the expected content contained within this class.
-     * <p>
-     * <pre>
-     * &lt;complexType>
-     *   &lt;complexContent>
-     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
-     *       &lt;sequence>
-     *         &lt;element name="RelationshipConstraint" maxOccurs="unbounded">
-     *           &lt;complexType>
-     *             &lt;complexContent>
-     *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
-     *                 &lt;sequence>
-     *                   &lt;any processContents='lax' namespace='##other' minOccurs="0"/>
-     *                 &lt;/sequence>
-     *                 &lt;attribute name="constraintType" use="required" type="{http://www.w3.org/2001/XMLSchema}anyURI"
-     * />
-     *               &lt;/restriction>
-     *             &lt;/complexContent>
-     *           &lt;/complexType>
-     *         &lt;/element>
-     *       &lt;/sequence>
-     *     &lt;/restriction>
-     *   &lt;/complexContent>
-     * &lt;/complexType>
-     * </pre>
-     */
     @XmlAccessorType(XmlAccessType.FIELD)
     @XmlType(name = "", propOrder = {
         "relationshipConstraint"

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TRelationshipType.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TRelationshipType.java
@@ -14,76 +14,21 @@
 
 package org.eclipse.winery.model.tosca;
 
-import org.eclipse.jdt.annotation.NonNull;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
 
-/**
- * <p>Java class for tRelationshipType complex type.
- * <p>
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;complexType name="tRelationshipType">
- *   &lt;complexContent>
- *     &lt;extension base="{http://docs.oasis-open.org/tosca/ns/2011/12}tEntityType">
- *       &lt;sequence>
- *         &lt;element name="InstanceStates" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tTopologyElementInstanceStates"
- * minOccurs="0"/>
- *         &lt;element name="SourceInterfaces" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;sequence>
- *                   &lt;element name="Interface" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tInterface"
- * maxOccurs="unbounded"/>
- *                 &lt;/sequence>
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *         &lt;element name="TargetInterfaces" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;sequence>
- *                   &lt;element name="Interface" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tInterface"
- * maxOccurs="unbounded"/>
- *                 &lt;/sequence>
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *         &lt;element name="ValidSource" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;attribute name="typeRef" use="required" type="{http://www.w3.org/2001/XMLSchema}QName" />
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *         &lt;element name="ValidTarget" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;attribute name="typeRef" use="required" type="{http://www.w3.org/2001/XMLSchema}QName" />
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *       &lt;/sequence>
- *       &lt;anyAttribute processContents='lax' namespace='##other'/>
- *     &lt;/extension>
- *   &lt;/complexContent>
- * &lt;/complexType>
- * </pre>
- */
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tRelationshipType", propOrder = {
     "instanceStates",
@@ -139,7 +84,7 @@ public class TRelationshipType extends TEntityType {
      *
      * @return possible object is {@link TTopologyElementInstanceStates }
      */
-    /*@Nullable*/
+    @Nullable
     public TTopologyElementInstanceStates getInstanceStates() {
         return instanceStates;
     }
@@ -158,8 +103,7 @@ public class TRelationshipType extends TEntityType {
      *
      * @return possible object is {@link TRelationshipType.SourceInterfaces }
      */
-    /*@Nullable*/
-    public TRelationshipType.SourceInterfaces getSourceInterfaces() {
+    public TRelationshipType.@Nullable SourceInterfaces getSourceInterfaces() {
         return sourceInterfaces;
     }
 
@@ -177,8 +121,7 @@ public class TRelationshipType extends TEntityType {
      *
      * @return possible object is {@link TRelationshipType.TargetInterfaces }
      */
-    /*@Nullable*/
-    public TRelationshipType.TargetInterfaces getTargetInterfaces() {
+    public TRelationshipType.@Nullable TargetInterfaces getTargetInterfaces() {
         return targetInterfaces;
     }
 
@@ -196,8 +139,7 @@ public class TRelationshipType extends TEntityType {
      *
      * @return possible object is {@link TRelationshipType.ValidSource }
      */
-    /*@Nullable*/
-    public TRelationshipType.ValidSource getValidSource() {
+    public TRelationshipType.@Nullable ValidSource getValidSource() {
         return validSource;
     }
 
@@ -215,8 +157,7 @@ public class TRelationshipType extends TEntityType {
      *
      * @return possible object is {@link TRelationshipType.ValidTarget }
      */
-    /*@Nullable*/
-    public TRelationshipType.ValidTarget getValidTarget() {
+    public TRelationshipType.@Nullable ValidTarget getValidTarget() {
         return validTarget;
     }
 

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TRequirementDefinition.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TRequirementDefinition.java
@@ -14,63 +14,21 @@
 
 package org.eclipse.winery.model.tosca;
 
-import org.eclipse.jdt.annotation.NonNull;
-
-import javax.xml.bind.annotation.*;
-import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
 
-/**
- * <p>Java class for tRequirementDefinition complex type.
- * <p>
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;complexType name="tRequirementDefinition">
- *   &lt;complexContent>
- *     &lt;extension base="{http://docs.oasis-open.org/tosca/ns/2011/12}tExtensibleElements">
- *       &lt;sequence>
- *         &lt;element name="Constraints" minOccurs="0">
- *           &lt;complexType>
- *             &lt;complexContent>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *                 &lt;sequence>
- *                   &lt;element name="Constraint" type="{http://docs.oasis-open.org/tosca/ns/2011/12}tConstraint"
- * maxOccurs="unbounded"/>
- *                 &lt;/sequence>
- *               &lt;/restriction>
- *             &lt;/complexContent>
- *           &lt;/complexType>
- *         &lt;/element>
- *       &lt;/sequence>
- *       &lt;attribute name="name" use="required" type="{http://www.w3.org/2001/XMLSchema}string" />
- *       &lt;attribute name="requirementType" use="required" type="{http://www.w3.org/2001/XMLSchema}QName" />
- *       &lt;attribute name="lowerBound" type="{http://www.w3.org/2001/XMLSchema}int" default="1" />
- *       &lt;attribute name="upperBound" default="1">
- *         &lt;simpleType>
- *           &lt;union>
- *             &lt;simpleType>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}nonNegativeInteger">
- *                 &lt;pattern value="([1-9]+[0-9]*)"/>
- *               &lt;/restriction>
- *             &lt;/simpleType>
- *             &lt;simpleType>
- *               &lt;restriction base="{http://www.w3.org/2001/XMLSchema}string">
- *                 &lt;enumeration value="unbounded"/>
- *               &lt;/restriction>
- *             &lt;/simpleType>
- *           &lt;/union>
- *         &lt;/simpleType>
- *       &lt;/attribute>
- *       &lt;anyAttribute processContents='lax' namespace='##other'/>
- *     &lt;/extension>
- *   &lt;/complexContent>
- * &lt;/complexType>
- * </pre>
- */
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tRequirementDefinition", propOrder = {
     "constraints"
@@ -123,8 +81,7 @@ public class TRequirementDefinition extends TExtensibleElements {
      *
      * @return possible object is {@link TRequirementDefinition.Constraints }
      */
-    /*@Nullable*/
-    public TRequirementDefinition.Constraints getConstraints() {
+    public TRequirementDefinition.@Nullable Constraints getConstraints() {
         return constraints;
     }
 

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TRequirementRef.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TRequirementRef.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2013-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,28 +14,18 @@
 
 package org.eclipse.winery.model.tosca;
 
-import org.eclipse.jdt.annotation.NonNull;
-
-import javax.xml.bind.annotation.*;
 import java.util.Objects;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlIDREF;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
 
-/**
- * <p>Java class for tRequirementRef complex type.
- * <p>
- * <p>The following schema fragment specifies the expected content contained within this class.
- * <p>
- * <pre>
- * &lt;complexType name="tRequirementRef">
- *   &lt;complexContent>
- *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
- *       &lt;attribute name="name" type="{http://www.w3.org/2001/XMLSchema}string" />
- *       &lt;attribute name="ref" use="required" type="{http://www.w3.org/2001/XMLSchema}IDREF" />
- *     &lt;/restriction>
- *   &lt;/complexContent>
- * &lt;/complexType>
- * </pre>
- */
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tRequirementRef")
 public class TRequirementRef {
@@ -61,41 +51,21 @@ public class TRequirementRef {
         return Objects.hash(name, ref);
     }
 
-    /**
-     * Gets the value of the name property.
-     *
-     * @return possible object is {@link String }
-     */
-    /*@Nullable*/
+    @Nullable
     public String getName() {
         return name;
     }
 
-    /**
-     * Sets the value of the name property.
-     *
-     * @param value allowed object is {@link String }
-     */
     public void setName(String value) {
         this.name = value;
     }
 
-    /**
-     * Gets the value of the ref property.
-     *
-     * @return possible object is {@link Object }
-     */
     @NonNull
     public Object getRef() {
         return ref;
     }
 
-    /**
-     * Sets the value of the ref property.
-     *
-     * @param value allowed object is {@link Object }
-     */
-    public void setRef(Object value) {
+    public void setRef(@NonNull Object value) {
         this.ref = value;
     }
 }

--- a/org.eclipse.winery.repository/pom.xml
+++ b/org.eclipse.winery.repository/pom.xml
@@ -170,13 +170,6 @@
             <version>2.2.5</version>
             <!--if updated to 2.2.11, java.lang.NoClassDefFoundError: com/sun/xml/bind/v2/model/annotation/AnnotationReader-->
         </dependency>
-        <!-- no review, but approval is required for test-only dependencies: http://wiki.eclipse.org/Development_Resources/IP/Test_and_Build_Dependencies -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
@@ -232,6 +225,18 @@
             <groupId>org.jgrapht</groupId>
             <artifactId>jgrapht-core</artifactId>
             <version>1.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>
@@ -295,9 +300,25 @@
                 <version>3.7.0</version>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.16</version>
+                <version>2.21.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-surefire-provider</artifactId>
+                        <version>${junit.platform.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>${junit.jupiter.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-params</artifactId>
+                        <version>${junit.jupiter.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/ImportUtilsTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/ImportUtilsTest.java
@@ -17,10 +17,12 @@ import org.eclipse.winery.common.ids.Namespace;
 import org.eclipse.winery.common.ids.XmlId;
 import org.eclipse.winery.common.ids.definitions.imports.XSDImportId;
 import org.eclipse.winery.repository.backend.ImportUtils;
-import org.junit.Assert;
-import org.junit.Test;
 
 import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImportUtilsTest extends TestWithGitBackedRepository {
 
@@ -33,6 +35,6 @@ public class ImportUtilsTest extends TestWithGitBackedRepository {
             new XmlId("CloudProviderProperties", false));
         Optional<String> importLocation = ImportUtils.getLocation(id);
 
-        Assert.assertEquals(true, importLocation.isPresent());
+        assertEquals(true, importLocation.isPresent());
     }
 }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/JAXBSupportTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/JAXBSupportTest.java
@@ -13,24 +13,24 @@
  *******************************************************************************/
 package org.eclipse.winery.repository;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class JAXBSupportTest {
 
     @Test
     public void createMarshaller() throws Exception {
-        Assert.assertNotNull(JAXBSupport.createMarshaller(true));
+        assertNotNull(JAXBSupport.createMarshaller(true));
     }
 
     @Test
     public void createUnmarshaller() throws Exception {
-        Assert.assertNotNull(JAXBSupport.createUnmarshaller());
+        assertNotNull(JAXBSupport.createUnmarshaller());
     }
 
     @Test
     public void JAXBContextIsNotNull() {
-        Assert.assertNotNull(JAXBSupport.context);
+        assertNotNull(JAXBSupport.context);
     }
-
 }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/VersionUtilsTestWithGitBackedRepository.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/VersionUtilsTestWithGitBackedRepository.java
@@ -21,8 +21,9 @@ import org.eclipse.winery.common.version.ToscaDiff;
 import org.eclipse.winery.common.version.VersionState;
 import org.eclipse.winery.common.version.VersionUtils;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This test class resides in the repository in order to make use of the git backed test suite.
@@ -41,18 +42,18 @@ public class VersionUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
         ToscaDiff id = diffNode.getChildrenMap().get("id");
         ToscaDiff topology = diffNode.getChildrenMap().get("topologyTemplate");
 
-        Assert.assertEquals(VersionState.CHANGED, diffNode.getState());
+        assertEquals(VersionState.CHANGED, diffNode.getState());
 
-        Assert.assertEquals(VersionState.CHANGED, name.getState());
-        Assert.assertEquals("ServiceTemplateWithFourPolicies_-w1-wip1", name.getNewValue());
-        Assert.assertEquals("ServiceTemplateWithFourPolicies", name.getOldValue());
+        assertEquals(VersionState.CHANGED, name.getState());
+        assertEquals("ServiceTemplateWithFourPolicies_-w1-wip1", name.getNewValue());
+        assertEquals("ServiceTemplateWithFourPolicies", name.getOldValue());
 
-        Assert.assertEquals(VersionState.CHANGED, name.getState());
-        Assert.assertEquals("ServiceTemplateWithFourPolicies_-w1-wip1", id.getNewValue());
-        Assert.assertEquals("ServiceTemplateWithFourPolicies", id.getOldValue());
+        assertEquals(VersionState.CHANGED, name.getState());
+        assertEquals("ServiceTemplateWithFourPolicies_-w1-wip1", id.getNewValue());
+        assertEquals("ServiceTemplateWithFourPolicies", id.getOldValue());
 
-        Assert.assertEquals(VersionState.CHANGED, topology.getState());
-        Assert.assertEquals(2, topology.getChildren().size());
+        assertEquals(VersionState.CHANGED, topology.getState());
+        assertEquals(2, topology.getChildren().size());
     }
 
     @Test
@@ -64,7 +65,7 @@ public class VersionUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
 
         ToscaDiff diffNode = VersionUtils.calculateDifferences(repository.getElement(oldVersion), repository.getElement(newVersion));
 
-        Assert.assertEquals(VersionState.UNCHANGED, diffNode.getState());
+        assertEquals(VersionState.UNCHANGED, diffNode.getState());
     }
 
     @Test
@@ -79,7 +80,7 @@ public class VersionUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
         ToscaDiff diffNode = VersionUtils.calculateDifferences(repository.getElement(oldVersion).getTopologyTemplate().getRelationshipTemplate("con_129"),
             repository.getElement(newVersion).getTopologyTemplate().getRelationshipTemplate("con_129"));
 
-        Assert.assertEquals(VersionState.UNCHANGED, diffNode.getState());
+        assertEquals(VersionState.UNCHANGED, diffNode.getState());
     }
 
     @Test
@@ -93,7 +94,7 @@ public class VersionUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
 
         ToscaDiff diffNode = VersionUtils.calculateDifferences(repository.getElement(oldVersion), repository.getElement(newVersion));
 
-        Assert.assertEquals(VersionState.UNCHANGED, diffNode.getState());
+        assertEquals(VersionState.UNCHANGED, diffNode.getState());
     }
 
     @Test
@@ -107,7 +108,7 @@ public class VersionUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
 
         ToscaDiff diffNode = VersionUtils.calculateDifferences(repository.getElement(oldVersion), repository.getElement(newVersion));
 
-        Assert.assertEquals(VersionState.UNCHANGED, diffNode.getState());
+        assertEquals(VersionState.UNCHANGED, diffNode.getState());
     }
 
     @Test
@@ -125,13 +126,13 @@ public class VersionUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
         ToscaDiff element1 = nodeTemplateDiff.get("0");
         ToscaDiff element2 = nodeTemplateDiff.get("1");
 
-        Assert.assertEquals(VersionState.CHANGED, diffNode.getState());
+        assertEquals(VersionState.CHANGED, diffNode.getState());
 
-        Assert.assertEquals("NodeTypeWithXmlElementProperty", element1.getElement());
-        Assert.assertEquals(VersionState.ADDED, element1.getState());
+        assertEquals("NodeTypeWithXmlElementProperty", element1.getElement());
+        assertEquals(VersionState.ADDED, element1.getState());
 
-        Assert.assertEquals("NodeTypeWithOneReqCapPairWithoutProperties", element2.getElement());
-        Assert.assertEquals(VersionState.REMOVED, element2.getState());
+        assertEquals("NodeTypeWithOneReqCapPairWithoutProperties", element2.getElement());
+        assertEquals(VersionState.REMOVED, element2.getState());
     }
 
     @Test
@@ -149,13 +150,13 @@ public class VersionUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
         ToscaDiff element1 = nodeTemplateDiff.get("0");
         ToscaDiff element2 = nodeTemplateDiff.get("1");
 
-        Assert.assertEquals("NodeTypeWithOneReqCapPairWithoutProperties", element1.getElement());
-        Assert.assertEquals(VersionState.ADDED, element1.getState());
+        assertEquals("NodeTypeWithOneReqCapPairWithoutProperties", element1.getElement());
+        assertEquals(VersionState.ADDED, element1.getState());
 
-        Assert.assertEquals("NodeTypeWithXmlElementProperty", element2.getElement());
-        Assert.assertEquals(VersionState.REMOVED, element2.getState());
+        assertEquals("NodeTypeWithXmlElementProperty", element2.getElement());
+        assertEquals(VersionState.REMOVED, element2.getState());
 
-        Assert.assertEquals(VersionState.CHANGED, diffNode.getState());
+        assertEquals(VersionState.CHANGED, diffNode.getState());
     }
 
     @Test
@@ -172,8 +173,8 @@ public class VersionUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
         Map<String, ToscaDiff> nodeTemplateDiff = diffNode.getChildrenMap().get("topologyTemplate").getChildrenMap().get("nodeTemplates").getChildrenMap();
         ToscaDiff element1 = nodeTemplateDiff.get("2");
 
-        Assert.assertEquals("NodeTypeWithTwoKVProperties", element1.getElement());
-        Assert.assertEquals(VersionState.CHANGED, element1.getState());
+        assertEquals("NodeTypeWithTwoKVProperties", element1.getElement());
+        assertEquals(VersionState.CHANGED, element1.getState());
     }
 
     @Test
@@ -187,7 +188,7 @@ public class VersionUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
 
         ToscaDiff diffNode = VersionUtils.calculateDifferences(repository.getElement(oldVersion), repository.getElement(newVersion));
 
-        Assert.assertEquals("## Changes from version -w1-wip3 to -w1-wip4\n" +
+        assertEquals("## Changes from version -w1-wip3 to -w1-wip4\n" +
                 "\n" +
                 "### Added\n" +
                 "- topologyTemplate/nodeTemplates/NodeTypeWithTwoKVProperties_2\n" +
@@ -221,7 +222,7 @@ public class VersionUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
 
         ToscaDiff toscaDiff = VersionUtils.calculateDifferences(repository.getElement(oldVersion), repository.getElement(newVersion));
 
-        Assert.assertEquals("## Changes from version 0.3.0-w2 to 0.3.4-w1\n" +
+        assertEquals("## Changes from version 0.3.0-w2 to 0.3.4-w1\n" +
                 "\n" +
                 "### Changed\n" +
                 "- name\n" +
@@ -240,7 +241,7 @@ public class VersionUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
 
         ToscaDiff toscaDiff = VersionUtils.calculateDifferences(repository.getElement(oldVersion), repository.getElement(newVersion));
 
-        Assert.assertEquals("## Changes from version  to -w1-wip1\n" +
+        assertEquals("## Changes from version  to -w1-wip1\n" +
                 "\n" +
                 "### Added\n" +
                 "- topologyTemplate/relationshipTemplates/NodeTypeWithoutProperties_RelationshipTypeWithoutProperties_NodeTypeWithTwoKVProperties\n" +
@@ -279,7 +280,7 @@ public class VersionUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
 
         ToscaDiff toscaDiff = VersionUtils.calculateDifferences(repository.getElement(oldVersion), repository.getElement(newVersion));
 
-        Assert.assertEquals("## Changes from version -w2-wip1 to -w2-wip2\n" +
+        assertEquals("## Changes from version -w2-wip1 to -w2-wip2\n" +
                 "\n" +
                 "### Changed\n" +
                 "- id\n" +

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/BackendUtilsTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/BackendUtilsTest.java
@@ -21,8 +21,8 @@ import org.eclipse.winery.model.tosca.TNodeTemplate;
 import org.eclipse.winery.model.tosca.TRelationshipTemplate;
 import org.eclipse.winery.model.tosca.TTopologyTemplate;
 import org.eclipse.winery.repository.datatypes.ids.elements.ArtifactTemplateSourceDirectoryId;
-import org.junit.Assert;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.xmlunit.matchers.CompareMatcher;
 
@@ -30,6 +30,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BackendUtilsTest {
 
@@ -50,7 +52,7 @@ public class BackendUtilsTest {
 
         TTopologyTemplate clone = BackendUtils.clone(topologyTemplate);
         List<TEntityTemplate> entityTemplatesClone = clone.getNodeTemplateOrRelationshipTemplate();
-        Assert.assertEquals(entityTemplates, entityTemplatesClone);
+        assertEquals(entityTemplates, entityTemplatesClone);
     }
 
     @Test
@@ -109,9 +111,9 @@ public class BackendUtilsTest {
         ArtifactTemplateSourceDirectoryId artifactTemplateSourceDirectoryId = new ArtifactTemplateSourceDirectoryId(artifactTemplateId);
 
         final RepositoryFileReference repositoryFileReference = BackendUtils.getRepositoryFileReference(Paths.get("main"), Paths.get("main", "file.txt"), artifactTemplateSourceDirectoryId);
-        Assert.assertEquals(artifactTemplateSourceDirectoryId, repositoryFileReference.getParent());
-        Assert.assertEquals(Optional.empty(), repositoryFileReference.getSubDirectory());
-        Assert.assertEquals("file.txt", repositoryFileReference.getFileName());
+        assertEquals(artifactTemplateSourceDirectoryId, repositoryFileReference.getParent());
+        assertEquals(Optional.empty(), repositoryFileReference.getSubDirectory());
+        assertEquals("file.txt", repositoryFileReference.getFileName());
     }
 
     @Test
@@ -121,9 +123,9 @@ public class BackendUtilsTest {
         final Path subDirectories = Paths.get("d1", "d2");
 
         final RepositoryFileReference repositoryFileReference = BackendUtils.getRepositoryFileReference(Paths.get("main"), Paths.get("main", "d1", "d2", "file.txt"), artifactTemplateSourceDirectoryId);
-        Assert.assertEquals(artifactTemplateSourceDirectoryId, repositoryFileReference.getParent());
-        Assert.assertEquals(Optional.of(subDirectories), repositoryFileReference.getSubDirectory());
-        Assert.assertEquals("file.txt", repositoryFileReference.getFileName());
+        assertEquals(artifactTemplateSourceDirectoryId, repositoryFileReference.getParent());
+        assertEquals(Optional.of(subDirectories), repositoryFileReference.getSubDirectory());
+        assertEquals("file.txt", repositoryFileReference.getFileName());
     }
 
 }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/BackendUtilsTestWithGitBackedRepository.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/BackendUtilsTestWithGitBackedRepository.java
@@ -13,7 +13,12 @@
  ********************************************************************************/
 package org.eclipse.winery.repository.backend;
 
-import org.apache.tika.mime.MediaType;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.xml.namespace.QName;
+
 import org.eclipse.winery.common.RepositoryFileReference;
 import org.eclipse.winery.common.Util;
 import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
@@ -26,13 +31,15 @@ import org.eclipse.winery.common.version.WineryVersion;
 import org.eclipse.winery.model.tosca.Definitions;
 import org.eclipse.winery.model.tosca.TPolicyTemplate;
 import org.eclipse.winery.repository.TestWithGitBackedRepository;
-import org.junit.Assert;
-import org.junit.Test;
 
-import javax.xml.namespace.QName;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.stream.Collectors;
+import org.apache.tika.mime.MediaType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BackendUtilsTestWithGitBackedRepository extends TestWithGitBackedRepository {
 
@@ -50,15 +57,14 @@ public class BackendUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
 
         BackendUtils.initializeProperties(repository, policyTemplate);
 
-        Assert.assertNotNull(policyTemplate.getProperties());
+        assertNotNull(policyTemplate.getProperties());
 
         LinkedHashMap<String, String> kvProperties = policyTemplate.getProperties().getKVProperties();
         LinkedHashMap<String, String> expectedPropertyKVS = new LinkedHashMap<>();
         expectedPropertyKVS.put("key1", "");
         expectedPropertyKVS.put("key2", "");
-        Assert.assertEquals(expectedPropertyKVS, kvProperties);
+        assertEquals(expectedPropertyKVS, kvProperties);
     }
-
 
     @Test
     public void initializePropertiesDoesNothingInTheCaseOfXmlElementProperties() throws Exception {
@@ -74,7 +80,7 @@ public class BackendUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
 
         BackendUtils.initializeProperties(repository, policyTemplate);
 
-        Assert.assertNull(policyTemplate.getProperties());
+        assertNull(policyTemplate.getProperties());
     }
 
     @Test
@@ -84,7 +90,7 @@ public class BackendUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
         DefinitionsChildId id = new NodeTypeId("http://opentosca.org/nodetypes", "NodeTypeWith5Versions_0.3.4-w3", false);
         List<WineryVersion> versions = BackendUtils.getAllVersionsOfOneDefinition(id);
 
-        Assert.assertEquals(5, versions.size());
+        assertEquals(5, versions.size());
     }
 
     @Test
@@ -94,8 +100,8 @@ public class BackendUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
         DefinitionsChildId id = new RelationshipTypeId("http://plain.winery.opentosca.org/relationshiptypes", "RelationshipTypeWithoutProperties", false);
         List<WineryVersion> versions = BackendUtils.getAllVersionsOfOneDefinition(id);
 
-        Assert.assertEquals(1, versions.size());
-        Assert.assertEquals("", versions.get(0).toString());
+        assertEquals(1, versions.size());
+        assertEquals("", versions.get(0).toString());
     }
 
     @Test
@@ -105,7 +111,7 @@ public class BackendUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
         DefinitionsChildId id = new NodeTypeId("http://opentosca.org/nodetypes", "NodeTypeWith5Versions_0.3.4-w3", false);
         List<WineryVersion> versions = BackendUtils.getAllVersionsOfOneDefinition(id);
 
-        versions.forEach(wineryVersion -> Assert.assertFalse(wineryVersion.isEditable()));
+        versions.forEach(wineryVersion -> assertFalse(wineryVersion.isEditable()));
     }
 
     @Test
@@ -119,12 +125,12 @@ public class BackendUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
 
         List<WineryVersion> versions = BackendUtils.getAllVersionsOfOneDefinition(id);
 
-        Assert.assertTrue(versions.get(0).isEditable());
+        assertTrue(versions.get(0).isEditable());
 
         List<WineryVersion> collect = versions.stream()
             .filter(item -> !item.isEditable())
             .collect(Collectors.toList());
-        Assert.assertEquals(4, collect.size());
+        assertEquals(4, collect.size());
     }
 
     @Test
@@ -139,12 +145,12 @@ public class BackendUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
 
         List<WineryVersion> versions = BackendUtils.getAllVersionsOfOneDefinition(id);
 
-        Assert.assertTrue(versions.get(0).isEditable());
+        assertTrue(versions.get(0).isEditable());
 
         List<WineryVersion> collect = versions.stream()
             .filter(item -> !item.isEditable())
             .collect(Collectors.toList());
-        Assert.assertEquals(4, collect.size());
+        assertEquals(4, collect.size());
     }
 
     @Test
@@ -156,7 +162,7 @@ public class BackendUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
         List<WineryVersion> versions = BackendUtils.getAllVersionsOfOneDefinition(policyTemplateId);
 
         // For convenience, we accept editing already existing components without versions
-        Assert.assertTrue(versions.get(0).isEditable());
+        assertTrue(versions.get(0).isEditable());
     }
 
     @Test
@@ -168,8 +174,8 @@ public class BackendUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
         List<WineryVersion> versionList = BackendUtils.getAllVersionsOfOneDefinition(id);
         WineryVersion version = versionList.get(versionList.size() - 2);
 
-        Assert.assertFalse(version.isEditable());
-        Assert.assertTrue(version.isReleasable());
+        assertFalse(version.isEditable());
+        assertTrue(version.isReleasable());
     }
 
     @Test
@@ -184,8 +190,8 @@ public class BackendUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
         List<WineryVersion> versionList = BackendUtils.getAllVersionsOfOneDefinition(id);
         WineryVersion version = versionList.get(versionList.size() - 2);
 
-        Assert.assertTrue(version.isEditable());
-        Assert.assertTrue(version.isReleasable());
+        assertTrue(version.isEditable());
+        assertTrue(version.isReleasable());
     }
 
     @Test
@@ -198,8 +204,8 @@ public class BackendUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
         ToscaDiff toscaDiff = BackendUtils.compare(newVersion, oldVersion);
         ToscaDiff properties = toscaDiff.getChildrenMap().get("winerysPropertiesDefinition");
 
-        Assert.assertEquals(VersionState.CHANGED, toscaDiff.getState());
-        Assert.assertEquals(VersionState.ADDED, properties.getState());
+        assertEquals(VersionState.CHANGED, toscaDiff.getState());
+        assertEquals(VersionState.ADDED, properties.getState());
     }
 
     @Test
@@ -212,9 +218,9 @@ public class BackendUtilsTestWithGitBackedRepository extends TestWithGitBackedRe
         ToscaDiff toscaDiff = BackendUtils.compare(newVersion, oldVersion);
         ToscaDiff properties = toscaDiff.getChildrenMap().get("winerysPropertiesDefinition").getChildrenMap().get("propertyDefinitionKVList");
 
-        Assert.assertEquals(VersionState.CHANGED, toscaDiff.getState());
-        Assert.assertEquals(VersionState.CHANGED, properties.getState());
-        Assert.assertEquals(3, properties.getChildren().size());
+        assertEquals(VersionState.CHANGED, toscaDiff.getState());
+        assertEquals(VersionState.CHANGED, properties.getState());
+        assertEquals(3, properties.getChildren().size());
     }
 }
 

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/IGenericRepositoryTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/IGenericRepositoryTest.java
@@ -16,13 +16,15 @@ package org.eclipse.winery.repository.backend;
 
 import org.eclipse.winery.common.ids.definitions.*;
 import org.eclipse.winery.repository.TestWithGitBackedRepository;
-import org.junit.Assert;
-import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class IGenericRepositoryTest extends TestWithGitBackedRepository {
 
@@ -37,6 +39,6 @@ public class IGenericRepositoryTest extends TestWithGitBackedRepository {
         PolicyTypeId policyTypeId = new PolicyTypeId("http://plain.winery.opentosca.org/policytypes", "PolicyTypeWithoutProperties", false);
 
         final Set<DefinitionsChildId> expected = new HashSet<>(Arrays.asList(nodeTypeWithoutPropertiesId, policyTemplateId, policyTypeId));
-        Assert.assertEquals(expected, referencedDefinitionsChildIds);
+        assertEquals(expected, referencedDefinitionsChildIds);
     }
 }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/consistencycheck/ConsistencyCheckerTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/consistencycheck/ConsistencyCheckerTest.java
@@ -14,11 +14,13 @@
 package org.eclipse.winery.repository.backend.consistencycheck;
 
 import org.eclipse.winery.common.ids.definitions.NodeTypeImplementationId;
-import org.junit.Assert;
-import org.junit.Test;
 
 import java.util.Collections;
 import java.util.EnumSet;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ConsistencyCheckerTest {
 
@@ -27,6 +29,6 @@ public class ConsistencyCheckerTest {
         NodeTypeImplementationId id = new NodeTypeImplementationId("http://winery.opentosca.org/test/nodetypeimplementations/fruits", "baobab_impl", false);
         ConsistencyErrorLogger errorLogger = new ConsistencyErrorLogger();
         ConsistencyChecker.checkNamespaceUri(errorLogger, EnumSet.of(ConsistencyCheckerVerbosity.NONE), id);
-        Assert.assertEquals(Collections.emptyMap(), errorLogger.getErrorList());
+        assertEquals(Collections.emptyMap(), errorLogger.getErrorList());
     }
 }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManagerTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/filebased/ConfigurationBasedNamespaceManagerTest.java
@@ -14,65 +14,66 @@
 package org.eclipse.winery.repository.backend.filebased;
 
 import org.apache.commons.configuration.BaseConfiguration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ConfigurationBasedNamespaceManagerTest {
 
     private ConfigurationBasedNamespaceManager configurationBasedNamespaceManager;
     
-    @Before
+    @BeforeEach
     public void initializeNamespaceManager() {
         this.configurationBasedNamespaceManager = new ConfigurationBasedNamespaceManager(new BaseConfiguration());
     }
     
     @Test
     public void openToscaNodeTypesCorrectlyProposed() {
-        Assert.assertEquals("otntyexample", this.configurationBasedNamespaceManager.generatePrefixProposal("http://opentosca.org/nodetypes/example", 0));
+        assertEquals("otntyexample", this.configurationBasedNamespaceManager.generatePrefixProposal("http://opentosca.org/nodetypes/example", 0));
     }
 
     @Test
     public void nonOpenToscaNodeTypesCorrectlyProposed() {
-        Assert.assertEquals("ntyexample", this.configurationBasedNamespaceManager.generatePrefixProposal("http://example.org/nodetypes/example", 0));
+        assertEquals("ntyexample", this.configurationBasedNamespaceManager.generatePrefixProposal("http://example.org/nodetypes/example", 0));
     }
 
     @Test
     public void openToscaNodeTypesCorrect() {
-        Assert.assertEquals("otntyexample", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example"));
+        assertEquals("otntyexample", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example"));
     }
 
     @Test
     public void openToscaNodeTypesCorrectAtSecondCall() {
-        Assert.assertEquals("otntyexample", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example"));
-        Assert.assertEquals("otntyexample", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example"));
+        assertEquals("otntyexample", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example"));
+        assertEquals("otntyexample", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example"));
     }
 
     @Test
     public void openToscaNodeTypesCorrectAtSimilarNamespaces() {
-        Assert.assertEquals("otntyexample", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example"));
-        Assert.assertEquals("otntyexample1", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example/example"));
+        assertEquals("otntyexample", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example"));
+        assertEquals("otntyexample1", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example/example"));
     }
 
     @Test
     public void openToscaNodeTypesCorrectAtSimilarNamespacesWithUniqueness() {
-        Assert.assertEquals("otntyexample", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example"));
-        Assert.assertEquals("otntyexample1", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example/example"));
+        assertEquals("otntyexample", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example"));
+        assertEquals("otntyexample1", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example/example"));
         
         // try again -> same prefixes have to be returned
-        Assert.assertEquals("otntyexample", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example"));
-        Assert.assertEquals("otntyexample1", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example/example"));
+        assertEquals("otntyexample", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example"));
+        assertEquals("otntyexample1", this.configurationBasedNamespaceManager.getPrefix("http://opentosca.org/nodetypes/example/example"));
     }
 
     @Test
     public void xmlNullNamespaceHasPrefix() {
         // the XML null namespace is the empty string
-        Assert.assertEquals("null", this.configurationBasedNamespaceManager.getPrefix(""));
+        assertEquals("null", this.configurationBasedNamespaceManager.getPrefix(""));
     }
 
     @Test
     public void nullNamespaceHasPrefix() {
-        Assert.assertEquals("null", this.configurationBasedNamespaceManager.getPrefix((String) null));
+        assertEquals("null", this.configurationBasedNamespaceManager.getPrefix((String) null));
     }
 
 }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/filebased/FilebasedRepositoryTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/filebased/FilebasedRepositoryTest.java
@@ -23,8 +23,6 @@ import org.eclipse.winery.repository.backend.BackendUtils;
 import org.eclipse.winery.repository.datatypes.ids.elements.ArtifactTemplateFilesDirectoryId;
 import org.eclipse.winery.repository.datatypes.ids.elements.ArtifactTemplateSourceDirectoryId;
 import org.eclipse.winery.repository.datatypes.ids.elements.DirectoryId;
-import org.junit.Assert;
-import org.junit.Test;
 
 import javax.xml.namespace.QName;
 import java.nio.file.Files;
@@ -33,30 +31,37 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.SortedSet;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class FilebasedRepositoryTest extends TestWithGitBackedRepository {
 
     @Test
     public void getAllDefinitionsChildIds() throws Exception {
         this.setRevisionTo("5fdcffa9ccd17743d5498cab0914081fc33606e9");
         SortedSet<XSDImportId> allImports = this.repository.getAllDefinitionsChildIds(XSDImportId.class);
-        Assert.assertEquals(1, allImports.size());
+        assertEquals(1, allImports.size());
     }
 
     @Test
     public void namespaceWithSpaceAtEndWorks() throws Exception {
         this.setRevisionTo("5fdcffa9ccd17743d5498cab0914081fc33606e9");
         NodeTypeId id = new NodeTypeId("http://www.example.org ", "id", false);
-        Assert.assertFalse(this.repository.exists(id));
+        assertFalse(this.repository.exists(id));
         this.repository.flagAsExisting(id);
-        Assert.assertTrue(this.repository.exists(id));
-        Assert.assertNotNull(this.repository.getElement(id));
+        assertTrue(this.repository.exists(id));
+        assertNotNull(this.repository.getElement(id));
     }
 
     @Test
     public void referenceCountIsOneForBaobab() throws Exception {
         this.setRevisionTo("5b7f106ab79a9ba137ece9167a79753dfc64ac84");
         final ArtifactTemplateId artifactTemplateId = new ArtifactTemplateId("http://winery.opentosca.org/test/artifacttemplates/fruits", "baobab_bananaInterface_IA", false);
-        Assert.assertEquals(1, this.repository.getReferenceCount(artifactTemplateId));
+        assertEquals(1, this.repository.getReferenceCount(artifactTemplateId));
     }
 
     @Test
@@ -68,7 +73,7 @@ public class FilebasedRepositoryTest extends TestWithGitBackedRepository {
         final FilebasedRepository repository = (FilebasedRepository) this.repository;
 
         final Path expected = Paths.get("artifacttemplates", "http%3A%2F%2Fwww.example.org", "at", "source", "dir1", "dir2", "dir3", "test.txt");
-        Assert.assertEquals(expected, repository.getRepositoryRoot().relativize(repository.ref2AbsolutePath(ref)));
+        assertEquals(expected, repository.getRepositoryRoot().relativize(repository.ref2AbsolutePath(ref)));
     }
 
     @Test
@@ -87,7 +92,7 @@ public class FilebasedRepositoryTest extends TestWithGitBackedRepository {
         BackendUtils.importDirectory(workingDir, this.repository, artifactTemplateSourceDirectoryId);
 
         RepositoryFileReference ref = new RepositoryFileReference(artifactTemplateSourceDirectoryId, subDirectories, "test.txt");
-        Assert.assertTrue(repository.exists(ref));
+        assertTrue(repository.exists(ref));
     }
 
     @Test
@@ -99,7 +104,7 @@ public class FilebasedRepositoryTest extends TestWithGitBackedRepository {
         final SortedSet<RepositoryFileReference> containedFiles = repository.getContainedFiles(directoryId);
 
         // TODO: real content (relative paths, ...) not checked
-        Assert.assertEquals(3, containedFiles.size());
+        assertEquals(3, containedFiles.size());
     }
 
     @Test
@@ -108,7 +113,7 @@ public class FilebasedRepositoryTest extends TestWithGitBackedRepository {
         ArtifactTemplateId artifactTemplateId = new ArtifactTemplateId("http://opentosca.org/artifacttemplates", "MyTinyTest", false);
         final TArtifactTemplate artifactTemplate = this.repository.getElement(artifactTemplateId);
         final TEntityType typeForTemplate = this.repository.getTypeForTemplate(artifactTemplate);
-        Assert.assertEquals(new QName("http://winery.opentosca.org/test/artifacttypes", "MiniArtifactType"), new QName(typeForTemplate.getTargetNamespace(), typeForTemplate.getName()));
+        assertEquals(new QName("http://winery.opentosca.org/test/artifacttypes", "MiniArtifactType"), new QName(typeForTemplate.getTargetNamespace(), typeForTemplate.getName()));
     }
 
     @Test
@@ -117,7 +122,7 @@ public class FilebasedRepositoryTest extends TestWithGitBackedRepository {
         DirectoryId fileDir = new ArtifactTemplateFilesDirectoryId(artifactTemplateWithFilesAndSourcesId);
         SortedSet<RepositoryFileReference> files = repository.getContainedFiles(fileDir);
         for (RepositoryFileReference ref : files) {
-            Assert.assertFalse("File " + ref.toString() + " contains empty sub directory", ref.getSubDirectory().isPresent() && ref.getSubDirectory().get().toString().equals(""));
+            assertFalse(ref.getSubDirectory().isPresent() && ref.getSubDirectory().get().toString().equals(""), "File " + ref.toString() + " contains empty sub directory");
         }
     }
 
@@ -125,14 +130,14 @@ public class FilebasedRepositoryTest extends TestWithGitBackedRepository {
     public void getStableDefinitionsOnly() throws Exception {
         this.setRevisionTo("e9e8443dfce1ccb0eee3a0b937b1c2e6ab7798df");
         SortedSet<NodeTypeId> stableNodeTypes = this.repository.getStableDefinitionsChildIdsOnly(NodeTypeId.class);
-        Assert.assertEquals(10, stableNodeTypes.size());
+        assertEquals(10, stableNodeTypes.size());
     }
 
     @Test
     public void getAllDefinitions() throws Exception {
         this.setRevisionTo("e9e8443dfce1ccb0eee3a0b937b1c2e6ab7798df");
         SortedSet<NodeTypeId> allNodeTypes = this.repository.getAllDefinitionsChildIds(NodeTypeId.class);
-        Assert.assertEquals(13, allNodeTypes.size());
+        assertEquals(13, allNodeTypes.size());
     }
 
     @Test
@@ -143,8 +148,8 @@ public class FilebasedRepositoryTest extends TestWithGitBackedRepository {
 
         this.repository.duplicate(old, newId);
 
-        Assert.assertTrue(this.repository.exists(old));
-        Assert.assertTrue(this.repository.exists(newId));
+        assertTrue(this.repository.exists(old));
+        assertTrue(this.repository.exists(newId));
     }
 
     @Test
@@ -155,7 +160,7 @@ public class FilebasedRepositoryTest extends TestWithGitBackedRepository {
 
         Collection<DefinitionsChildId> childIds = this.repository.getReferencingDefinitionsChildIds(element);
 
-        Assert.assertEquals(1, childIds.size());
+        assertEquals(1, childIds.size());
     }
 
     @Test
@@ -165,7 +170,7 @@ public class FilebasedRepositoryTest extends TestWithGitBackedRepository {
 
         Collection<DefinitionsChildId> childIds = this.repository.getReferencingDefinitionsChildIds(id);
 
-        Assert.assertEquals(4, childIds.size());
+        assertEquals(4, childIds.size());
     }
 
     @Test
@@ -175,7 +180,7 @@ public class FilebasedRepositoryTest extends TestWithGitBackedRepository {
 
         Collection<DefinitionsChildId> childIds = this.repository.getReferencingDefinitionsChildIds(id);
 
-        Assert.assertEquals(2, childIds.size());
+        assertEquals(2, childIds.size());
     }
 
     @Test
@@ -185,6 +190,6 @@ public class FilebasedRepositoryTest extends TestWithGitBackedRepository {
 
         Collection<DefinitionsChildId> childIds = this.repository.getReferencingDefinitionsChildIds(id);
 
-        Assert.assertEquals(2, childIds.size());
+        assertEquals(2, childIds.size());
     }
 }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/xsd/RepositoryBasedXsdImportManagerTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/backend/xsd/RepositoryBasedXsdImportManagerTest.java
@@ -14,10 +14,12 @@
 package org.eclipse.winery.repository.backend.xsd;
 
 import org.eclipse.winery.repository.TestWithGitBackedRepository;
-import org.junit.Assert;
-import org.junit.Test;
 
 import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RepositoryBasedXsdImportManagerTest extends TestWithGitBackedRepository {
 
@@ -28,7 +30,7 @@ public class RepositoryBasedXsdImportManagerTest extends TestWithGitBackedReposi
         RepositoryBasedXsdImportManager manager = (RepositoryBasedXsdImportManager) this.repository.getXsdImportManager();
         List<NamespaceAndDefinedLocalNames> list = manager.getAllDeclaredElementsLocalNames();
 
-        Assert.assertEquals(1, list.size());
+        assertEquals(1, list.size());
     }
 
     @Test
@@ -38,6 +40,6 @@ public class RepositoryBasedXsdImportManagerTest extends TestWithGitBackedReposi
         RepositoryBasedXsdImportManager manager = (RepositoryBasedXsdImportManager) this.repository.getXsdImportManager();
         List<NamespaceAndDefinedLocalNames> list = manager.getAllDefinedTypesLocalNames();
 
-        Assert.assertEquals(1, list.size());
+        assertEquals(1, list.size());
     }
 }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/driverspecificationandinjection/DASpecificationTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/driverspecificationandinjection/DASpecificationTest.java
@@ -18,7 +18,6 @@ import org.eclipse.winery.common.ids.definitions.ArtifactTypeId;
 import org.eclipse.winery.common.ids.definitions.ServiceTemplateId;
 import org.eclipse.winery.model.tosca.*;
 import org.eclipse.winery.repository.TestWithGitBackedRepository;
-import org.junit.Test;
 
 import javax.xml.namespace.QName;
 import java.util.ArrayList;
@@ -26,8 +25,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DASpecificationTest extends TestWithGitBackedRepository {
 

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/driverspecificationandinjection/DriverInjectionTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/driverspecificationandinjection/DriverInjectionTest.java
@@ -21,13 +21,14 @@ import org.eclipse.winery.model.tosca.TRelationshipTemplate;
 import org.eclipse.winery.model.tosca.TTopologyTemplate;
 import org.eclipse.winery.model.tosca.utils.ModelUtilities;
 import org.eclipse.winery.repository.TestWithGitBackedRepository;
-import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DriverInjectionTest extends TestWithGitBackedRepository {
 

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/export/CsarExporterTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/export/CsarExporterTest.java
@@ -13,18 +13,21 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.export;
 
-import org.eclipse.winery.common.ids.definitions.ArtifactTemplateId;
-import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
-import org.eclipse.winery.repository.TestWithGitBackedRepository;
-import org.eclipse.winery.repository.backend.RepositoryFactory;
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+
+import org.eclipse.winery.common.ids.definitions.ArtifactTemplateId;
+import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
+import org.eclipse.winery.repository.TestWithGitBackedRepository;
+import org.eclipse.winery.repository.backend.RepositoryFactory;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class CsarExporterTest extends TestWithGitBackedRepository {
 
@@ -42,8 +45,8 @@ public class CsarExporterTest extends TestWithGitBackedRepository {
             ZipEntry entry;
             while ((entry = zis.getNextEntry()) != null) {
                 String name = entry.getName();
-                Assert.assertNotNull(name);
-                Assert.assertFalse("name contains backslashes", name.contains("\\"));
+                assertNotNull(name);
+                assertFalse(name.contains("\\"), "name contains backslashes");
             }
         }
     }

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/export/ToscaExportUtilTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/export/ToscaExportUtilTest.java
@@ -13,15 +13,16 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.export;
 
-import org.apache.commons.io.output.NullOutputStream;
-import org.eclipse.winery.repository.TestWithGitBackedRepository;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import java.util.HashMap;
 import java.util.Map;
 
-@Ignore("not finished - CSARExporterTest is currently the way to go")
+import org.eclipse.winery.repository.TestWithGitBackedRepository;
+
+import org.apache.commons.io.output.NullOutputStream;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+@Disabled("not finished - CSARExporterTest is currently the way to go")
 public class ToscaExportUtilTest extends TestWithGitBackedRepository {
 
     @Test

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/splitting/SplittingTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/splitting/SplittingTest.java
@@ -14,33 +14,37 @@
 
 package org.eclipse.winery.repository.splitting;
 
-import org.eclipse.winery.common.ids.definitions.ServiceTemplateId;
-import org.eclipse.winery.model.tosca.*;
-import org.eclipse.winery.model.tosca.utils.ModelUtilities;
-import org.eclipse.winery.repository.TestWithGitBackedRepository;
-import org.eclipse.winery.repository.backend.RepositoryFactory;
-
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.eclipse.winery.common.ids.definitions.ServiceTemplateId;
+import org.eclipse.winery.model.tosca.TEntityTemplate;
+import org.eclipse.winery.model.tosca.TNodeTemplate;
+import org.eclipse.winery.model.tosca.TRelationshipTemplate;
+import org.eclipse.winery.model.tosca.TServiceTemplate;
+import org.eclipse.winery.model.tosca.TTopologyTemplate;
+import org.eclipse.winery.model.tosca.utils.ModelUtilities;
+import org.eclipse.winery.repository.TestWithGitBackedRepository;
+import org.eclipse.winery.repository.backend.RepositoryFactory;
 
-@Ignore("Needs to be updated to public test cases")
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Disabled("Needs to be updated to public test cases")
 public class SplittingTest extends TestWithGitBackedRepository {
 
     private Splitting splitting = new Splitting();
     private TTopologyTemplate topologyTemplate;
     private TTopologyTemplate topologyTemplate2;
 
-    @Before
+    @BeforeEach
     public void initialize() throws Exception {
         ServiceTemplateId id = new ServiceTemplateId("http://www.example.org", "ST", false);
         ServiceTemplateId id2 = new ServiceTemplateId("http://opentosca.org/servicetemplates", "FlinkApp_Demo_Small_On_OpenStack", false);

--- a/org.eclipse.winery.topologymodeler.ui/src/app/models/enums.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/models/enums.ts
@@ -44,3 +44,9 @@ export enum toggleModalType {
     DeploymentArtifacts = 'DEPLOYMENT_ARTIFACTS',
     Policies = 'POLICIES',
 }
+
+export enum PropertyDefinitionType {
+    NONE = 'NONE',
+    KV = 'KV',
+    XML = 'XML'
+}

--- a/org.eclipse.winery.topologymodeler.ui/src/app/models/groupedNodeTypeModel.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/models/groupedNodeTypeModel.ts
@@ -1,5 +1,5 @@
-<!--
- * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -10,17 +10,12 @@
  * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
--->
+ *******************************************************************************/
 
-<winery-toscatype-table
-    [toscaType]="'deploymentArtifacts'"
-    [currentNodeData]="currentNodeData"
-    [toscaTypeData]="deploymentArtifacts">
-</winery-toscatype-table>
+export interface GroupedNodeTypeModel {
+    children: Array<NodeTypeModel>; id: string; text: string;
+}
 
-<div class="button-wrapper">
-    <div (click)="toggleModal($event);" class="btn btn-sm btn-modal" style="display: block;">
-        Add new Deployment Artifact
-    </div>
-</div>
-
+export interface NodeTypeModel {
+    full: any; id: string; text: string;
+}

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.html
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/node.component.html
@@ -109,7 +109,6 @@
                 (toggleModalHandler)="sendToggleAction($event)"
                 [currentNodeData]="{entityTypes: entityTypes,
                                     nodeTemplate: nodeTemplate,
-                                    currentNodePart: 'PROPERTIES',
                                     propertyDefinitionType: propertyDefinitionType}">
             </winery-properties>
         </accordion-group>

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/policies/policies.component.html
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/policies/policies.component.html
@@ -12,10 +12,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 -->
 
-<winery-properties-content
-    [currentNodeData]="currentNodeData">
-</winery-properties-content>
-
 <winery-toscatype-table
     [toscaType]="'policies'"
     [currentNodeData]="currentNodeData"

--- a/org.eclipse.winery.topologymodeler.ui/src/app/node/properties-content/properties-content.component.ts
+++ b/org.eclipse.winery.topologymodeler.ui/src/app/node/properties-content/properties-content.component.ts
@@ -19,6 +19,7 @@ import { IWineryState } from '../../redux/store/winery.store';
 import { WineryActions } from '../../redux/actions/winery.actions';
 import { Subscription } from 'rxjs/Subscription';
 import { JsPlumbService } from '../../services/jsPlumbService';
+import { PropertyDefinitionType } from '../../models/enums';
 
 @Component({
     selector: 'winery-properties-content',
@@ -43,21 +44,17 @@ export class PropertiesContentComponent implements OnInit, OnChanges, OnDestroy 
      * Angular lifecycle event.
      */
     ngOnChanges(changes: SimpleChanges) {
-        setTimeout(() => {
-            if (this.currentNodeData.currentNodePart === 'PROPERTIES') {
-                if (changes.currentNodeData.currentValue.nodeTemplate.properties) {
-                    try {
-                        const currentProperties = changes.currentNodeData.currentValue.nodeTemplate.properties;
-                        if (this.currentNodeData.propertyDefinitionType === 'KV') {
-                            this.nodeProperties = currentProperties.kvproperties;
-                        } else if (this.currentNodeData.propertyDefinitionType === 'XML') {
-                            this.nodeProperties = currentProperties.any;
-                        }
-                    } catch (e) {
-                    }
+        if (changes.currentNodeData.currentValue.nodeTemplate.properties) {
+            try {
+                const currentProperties = changes.currentNodeData.currentValue.nodeTemplate.properties;
+                if (this.currentNodeData.propertyDefinitionType === PropertyDefinitionType.KV) {
+                    this.nodeProperties = currentProperties.kvproperties;
+                } else if (this.currentNodeData.propertyDefinitionType === PropertyDefinitionType.XML) {
+                    this.nodeProperties = currentProperties.any;
                 }
+            } catch (e) {
             }
-        }, 1);
+        }
         // repaint jsPlumb to account for height change of the accordion
         setTimeout(() => this.jsPlumbService.getJsPlumbInstance().repaintEverything(), 1);
     }
@@ -66,14 +63,12 @@ export class PropertiesContentComponent implements OnInit, OnChanges, OnDestroy 
      * Angular lifecycle event.
      */
     ngOnInit() {
-
         if (this.currentNodeData.nodeTemplate.properties) {
-            console.log(this.currentNodeData);
             try {
                 const currentProperties = this.currentNodeData.nodeTemplate.properties;
-                if (this.currentNodeData.propertyDefinitionType === 'KV') {
+                if (this.currentNodeData.propertyDefinitionType === PropertyDefinitionType.KV) {
                     this.nodeProperties = currentProperties.kvproperties;
-                } else if (this.currentNodeData.propertyDefinitionType === 'XML') {
+                } else if (this.currentNodeData.propertyDefinitionType === PropertyDefinitionType.XML) {
                     this.nodeProperties = currentProperties.any;
                 }
             } catch (e) {
@@ -92,22 +87,18 @@ export class PropertiesContentComponent implements OnInit, OnChanges, OnDestroy 
             .debounceTime(300)
             .distinctUntilChanged()
             .subscribe(value => {
-                if (this.currentNodeData.propertyDefinitionType === 'KV') {
+                if (this.currentNodeData.propertyDefinitionType === PropertyDefinitionType.KV) {
                     this.nodeProperties[this.key] = value;
                 } else {
                     this.nodeProperties = value;
                 }
-                switch (this.currentNodeData.currentNodePart) {
-                    case 'PROPERTIES':
-                        this.$ngRedux.dispatch(this.actions.setProperty({
-                            nodeProperty: {
-                                newProperty: this.nodeProperties,
-                                propertyType: this.currentNodeData.propertyDefinitionType,
-                                nodeId: this.currentNodeData.nodeTemplate.id
-                            }
-                        }));
-                        break;
-                }
+                this.$ngRedux.dispatch(this.actions.setProperty({
+                    nodeProperty: {
+                        newProperty: this.nodeProperties,
+                        propertyType: this.currentNodeData.propertyDefinitionType,
+                        nodeId: this.currentNodeData.nodeTemplate.id
+                    }
+                }));
             }));
     }
 

--- a/org.eclipse.winery.yaml.common/pom.xml
+++ b/org.eclipse.winery.yaml.common/pom.xml
@@ -74,10 +74,6 @@
             <version>1.11</version>
         </dependency>
     </dependencies>
-    <properties>
-        <junit.jupiter.version>5.0.2</junit.jupiter.version>
-        <junit.platform.version>1.0.2</junit.platform.version>
-    </properties>
     <url>http://www.eclipse.org/winery</url>
     <organization>
         <name>Eclipse.org - Winery Project</name>
@@ -106,7 +102,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>2.21.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.junit.platform</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <junit.jupiter.version>5.2.0</junit.jupiter.version>
+        <junit.platform.version>1.2.0</junit.platform.version>
+        <checkstyle.config.location>checkstyle.xml</checkstyle.config.location>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <modules>
         <module>org.eclipse.winery.model.bpmn4tosca</module>


### PR DESCRIPTION
Reduced the loading time of the node template properties display

- Start and end date: 2018-05-17 to 2018-05-20
- Contributor: Thommy Zelenik, @zelenikty
- Supervisor: Karoline Saatkamp, @saatkamp, Lukas Harzenetter, @lharzenetter, Oliver Kopp, @koppor

Node template properties are now faster displayed as before. Next step: Display the properties upon application load

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request.
- [x] Branch name checked. That means, the branch name starts with `thesis/`, `fix/`, ...
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for UI changes)
