### PR TITLE
[Bugfix] Fix import of ArtifactTemplate files to /ns/id/files/ns/id/...

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/importing/CsarImporter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/importing/CsarImporter.java
@@ -834,14 +834,8 @@ public class CsarImporter {
                 errors.add(String.format("File %1$s does not exist", p.toString()));
                 return;
             }
-            Path subDirectory = rootPath.relativize(p).getParent();
-            RepositoryFileReference fref;
-            // files are stored in "files/" or in "sources/"
-            if ((subDirectory == null) || (subDirectory.getParent().toString().endsWith(pathInsideRepo))) {
-                fref = new RepositoryFileReference(directoryId, p.getFileName().toString());
-            } else {
-                fref = new RepositoryFileReference(directoryId, subDirectory, p.getFileName().toString());
-            }
+            // directoryId already identifies the subdirectory
+            RepositoryFileReference fref = new RepositoryFileReference(directoryId, p.getFileName().toString());
             importFile(p, fref, tmf, rootPath, errors);
         }
     }


### PR DESCRIPTION
Signed-off-by: Vladimir Yussupov <v.yussupov@gmail.com>

Fixes a bug of wrong nesting of ArtifactTemplate files during import.

Start and end date: 2018-06-05 to 2018-06-06
Contributor: Vladimir Yussupov @v-yussupov

CsarImporter was calculating a subdirectory for a provided ArtifactTemplate's directoryId which lead to redundant nesting of folders.

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request.
- [x] Branch name checked. That means, the branch name starts with `thesis/`, `fix/`, ...
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Ensure to use auto format in **all** files
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for UI changes)
