### PR TITLE
[WIP] Move and revise topology completion code

### DIFF
--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/topologytemplates/TopologyTemplateResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/servicetemplates/topologytemplates/TopologyTemplateResource.java
@@ -39,6 +39,8 @@ import org.eclipse.winery.model.tosca.TRelationshipTemplate;
 import org.eclipse.winery.model.tosca.TTopologyTemplate;
 import org.eclipse.winery.model.tosca.utils.ModelUtilities;
 import org.eclipse.winery.repository.backend.BackendUtils;
+import org.eclipse.winery.repository.backend.RepositoryFactory;
+import org.eclipse.winery.repository.completion.topologycompletion.CompletionInterface;
 import org.eclipse.winery.repository.configuration.Environment;
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources._support.dataadapter.composeadapter.CompositionData;
@@ -296,5 +298,18 @@ public class TopologyTemplateResource {
         } catch (Exception e) {
             return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).build();
         }
+    }
+    
+    @POST
+    @Path("complete/")
+    @Consumes(MediaType.APPLICATION_XML)
+    @Produces(MediaType.APPLICATION_XML)
+    public Response complete () {
+        CompletionInterface completionInterface = new CompletionInterface();
+        ServiceTemplateId serviceTemplateId = (ServiceTemplateId)  this.serviceTemplateRes.getId();
+        completionInterface.complete(serviceTemplateId, RepositoryFactory.getRepository(),true,null,false,false);
+
+        return null;
+        
     }
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/analyzer/DeferredAnalyzer.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/analyzer/DeferredAnalyzer.java
@@ -12,12 +12,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer;
+package org.eclipse.winery.repository.completion.analyzer;
 
 import org.eclipse.winery.model.tosca.TNodeTemplate;
 import org.eclipse.winery.model.tosca.TRelationshipTemplate;
 import org.eclipse.winery.model.tosca.TTopologyTemplate;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.Constants;
+import org.eclipse.winery.repository.completion.helper.Constants;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/analyzer/PlaceHolderAnalyzer.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/analyzer/PlaceHolderAnalyzer.java
@@ -12,12 +12,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer;
+package org.eclipse.winery.repository.completion.analyzer;
 
+import org.eclipse.winery.common.ids.definitions.NodeTypeId;
 import org.eclipse.winery.model.tosca.TNodeTemplate;
 import org.eclipse.winery.model.tosca.TNodeType;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.Constants;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.Utils;
+import org.eclipse.winery.repository.completion.helper.Constants;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +40,7 @@ public class PlaceHolderAnalyzer {
         // Check the type of the NodeTemplates, write them to a list if the type is derived from the common place holder type.
         for (TNodeTemplate nodeTemplate : toscaAnalyzer.getNodeTemplates()) {
 
-            TNodeType nodeType = Utils.getNodeTypeForId(toscaAnalyzer.getNodeTypes(), nodeTemplate.getType());
+            TNodeType nodeType = toscaAnalyzer.getRepository().getElement(new NodeTypeId(nodeTemplate.getType()));
 
             if (nodeType != null && nodeType.getDerivedFrom() != null && nodeType.getDerivedFrom().getTypeRef().getLocalPart().equals(Constants.PLACE_HOLDER_QNAME.getLocalPart()) &&
                 nodeType.getDerivedFrom().getTypeRef().getNamespaceURI().equals(Constants.PLACE_HOLDER_QNAME.getNamespaceURI())) {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/analyzer/RequirementAnalyzer.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/analyzer/RequirementAnalyzer.java
@@ -12,10 +12,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer;
+package org.eclipse.winery.repository.completion.analyzer;
 
+import org.eclipse.winery.common.ids.definitions.NodeTypeId;
 import org.eclipse.winery.model.tosca.*;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.Utils;
+import org.eclipse.winery.repository.completion.helper.Utils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,7 +44,7 @@ public class RequirementAnalyzer {
 
             List<TRequirement> requirements = new ArrayList<>();
 
-            TNodeType nodeType = Utils.getNodeTypeForId(toscaAnalyzer.getNodeTypes(), nodeTemplate.getType());
+            TNodeType nodeType = toscaAnalyzer.getRepository().getElement(new NodeTypeId(nodeTemplate.getType()));
 
             if (nodeType.getRequirementDefinitions() != null && !nodeType.getRequirementDefinitions().getRequirementDefinition().isEmpty()) {
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/analyzer/TOSCAAnalyzer.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/analyzer/TOSCAAnalyzer.java
@@ -12,12 +12,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer;
+package org.eclipse.winery.repository.completion.analyzer;
 
+import org.eclipse.winery.common.ids.definitions.NodeTypeId;
+import org.eclipse.winery.common.ids.definitions.RelationshipTypeId;
+import org.eclipse.winery.common.ids.definitions.RequirementTypeId;
 import org.eclipse.winery.model.tosca.*;
+import org.eclipse.winery.repository.backend.IRepository;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * This class contains several methods to analyze the content of a TOSCA {@link TTopologyTemplate} and to fill a data model
@@ -25,14 +30,30 @@ import java.util.List;
  */
 public class TOSCAAnalyzer {
 
-    // lists containing the elements of a topology
-    List<TNodeTemplate> nodeTemplates = new ArrayList<TNodeTemplate>();
-    List<TRelationshipTemplate> relationshipTemplates = new ArrayList<TRelationshipTemplate>();
-    List<TRequirement> requirements = new ArrayList<TRequirement>();
+    private IRepository repository;
+    private List<TRequirementType> requirementTypes;
+    private List<TRelationshipType> relationshipTypes;
+    private List<TNodeType> nodeTypes;
 
-    List<TNodeType> nodeTypes;
-    List<TRelationshipType> relationshipTypes;
-    List<TRequirementType> requirementTypes;
+    private List <TNodeTemplate> nodeTemplates;
+    private List<TRelationshipTemplate> relationshipTemplates;
+    private List<TRequirement> requirements;
+
+    public TOSCAAnalyzer(IRepository repository) {
+
+        requirementTypes = repository.getAllDefinitionsChildIds(RequirementTypeId.class).stream().map(id -> repository.getElement(id)).collect(Collectors.toList());
+        relationshipTypes = repository.getAllDefinitionsChildIds(RelationshipTypeId.class).stream().map(id -> repository.getElement(id)).collect(Collectors.toList());
+        nodeTypes = repository.getAllDefinitionsChildIds(NodeTypeId.class).stream().map(id -> repository.getElement(id)).collect(Collectors.toList());
+
+        // lists containing the elements of a topology
+        nodeTemplates = new ArrayList<TNodeTemplate>();
+        relationshipTemplates = new ArrayList<TRelationshipTemplate>();
+        requirements = new ArrayList<TRequirement>();
+        
+        this.repository = repository;
+    }
+    
+
 
     /**
      * This method analyzes the TOSCA {@link TTopologyTemplate} for {@link TNodeTemplate}s, {@link TRelationshipTemplate}s
@@ -57,19 +78,6 @@ public class TOSCAAnalyzer {
                 relationshipTemplates.add((TRelationshipTemplate) entityTemplate);
             }
         }
-    }
-
-    /**
-     * Setter for the types received from the Winery repository.
-     *
-     * @param nodeTypeXMLStrings         a list of {@link TNodeType}s from the Winery repository
-     * @param relationshipTypeXMLStrings a list of {@link TRelationshipType}s from the Winery repository
-     * @param requirementTypeList        a list of {@link TRequirementType}s from the Winery repository
-     */
-    public void setTypes(List<TNodeType> nodeTypes, List<TRelationshipType> relationshipTypes, List<TRequirementType> requirementTypes) {
-        this.nodeTypes = nodeTypes;
-        this.relationshipTypes = relationshipTypes;
-        this.requirementTypes = requirementTypes;
     }
 
     /**
@@ -98,34 +106,7 @@ public class TOSCAAnalyzer {
     public List<TRequirement> getRequirements() {
         return requirements;
     }
-
-    /**
-     * Returns the {@link TRelationshipType}s of the topology.
-     *
-     * @return the {@link TRelationshipType}s as a list
-     */
-    public List<TRelationshipType> getRelationshipTypes() {
-        return relationshipTypes;
-    }
-
-    /**
-     * Returns the {@link TNodeType}s of the topology.
-     *
-     * @return the {@link TNodeType}s as a list
-     */
-    public List<TNodeType> getNodeTypes() {
-        return nodeTypes;
-    }
-
-    /**
-     * Returns the {@link TRequirementType}s of the topology.
-     *
-     * @return the {@link TRequirementType}s as a list
-     */
-    public List<TRequirementType> getRequirementTypes() {
-        return requirementTypes;
-    }
-
+    
     /**
      * Clears all the templates from the data model before the analysis of a topology is restarted.
      */
@@ -133,5 +114,21 @@ public class TOSCAAnalyzer {
         nodeTemplates.clear();
         relationshipTemplates.clear();
         requirements.clear();
+    }
+
+    public IRepository getRepository() {
+        return repository;
+    }
+
+    public List<TRequirementType> getRequirementTypes() {
+        return requirementTypes;
+    }
+
+    public List<TRelationshipType> getRelationshipTypes() {
+        return relationshipTypes;
+    }
+
+    public List<TNodeType> getNodeTypes() {
+        return nodeTypes;
     }
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/analyzer/package-info.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/analyzer/package-info.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 
 /**
- * This package contains helper classes and methods to assist the completion.
+ * This package contains classes and methods to analyze a TOSCA {@link org.opentosca.model.tosca.TTopologyTemplate} for its content.
  */
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.helper;
+package org.eclipse.winery.repository.completion.analyzer;
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/helper/Constants.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/helper/Constants.java
@@ -12,9 +12,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.helper;
-
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion.CompletionInterface;
+package org.eclipse.winery.repository.completion.helper;
 
 import javax.xml.namespace.QName;
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/helper/JAXBHelper.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/helper/JAXBHelper.java
@@ -12,7 +12,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.helper;
+package org.eclipse.winery.repository.completion.helper;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/helper/NodeTemplateConnector.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/helper/NodeTemplateConnector.java
@@ -12,13 +12,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.helper;
+package org.eclipse.winery.repository.completion.helper;
 
 import org.eclipse.winery.model.tosca.TCapability;
 import org.eclipse.winery.model.tosca.TNodeTemplate;
 import org.eclipse.winery.model.tosca.TRelationshipType;
 import org.eclipse.winery.model.tosca.TRequirement;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.TOSCAAnalyzer;
+import org.eclipse.winery.repository.completion.analyzer.TOSCAAnalyzer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +40,7 @@ public class NodeTemplateConnector {
     public static List<TRelationshipType> findRelationshipType(TNodeTemplate source, TNodeTemplate target, TOSCAAnalyzer toscaAnalyzer, TRequirement requirement) {
 
         List<TRelationshipType> suitableRelationshipTypes = new ArrayList<TRelationshipType>();
+        
         List<TRelationshipType> allRelationshipTypes = toscaAnalyzer.getRelationshipTypes();
 
         // in case the connection to a placeholder is searched, no requirement exists

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/helper/RESTHelper.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/helper/RESTHelper.java
@@ -12,7 +12,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.helper;
+package org.eclipse.winery.repository.completion.helper;
 
 import org.eclipse.winery.common.Util;
 import org.eclipse.winery.model.tosca.TTopologyTemplate;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/helper/Utils.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/helper/Utils.java
@@ -12,10 +12,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.helper;
+package org.eclipse.winery.repository.completion.helper;
 
 import org.eclipse.winery.model.tosca.*;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.TOSCAAnalyzer;
+import org.eclipse.winery.repository.completion.analyzer.TOSCAAnalyzer;
 import org.slf4j.LoggerFactory;
 
 import javax.xml.namespace.QName;
@@ -60,14 +60,9 @@ public class Utils {
 
         return possibleNodeTypes;
     }
-
-    /**
-     * Generates a random {@link UUID} exclusively used by the {@link TemplateBuilder}.
-     *
-     * @return the generated {@link UUID} id
-     */
+    
     public static String createRandomID() {
-        return UUID.randomUUID().toString();
+        return UUID.randomUUID().toString().replaceAll("-", "");
     }
 
     /**

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/helper/package-info.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/helper/package-info.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 
 /**
- * this package contains classes to complete a topology template
+ * This package contains helper classes and methods to assist the completion.
  */
-package org.eclipse.winery.topologymodeler.addons.topologycompleter;
+package org.eclipse.winery.repository.completion.helper;
+

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/package-info.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/package-info.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 
 /**
- * This package contains classes and methods to analyze a TOSCA {@link org.opentosca.model.tosca.TTopologyTemplate} for its content.
+ * this package contains classes to complete a topology template
  */
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer;
-
+package org.eclipse.winery.repository.completion;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/placeholderhandling/PlaceHolderHandler.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/placeholderhandling/PlaceHolderHandler.java
@@ -12,12 +12,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.placeholderhandling;
+package org.eclipse.winery.repository.completion.placeholderhandling;
 
 import org.eclipse.winery.model.tosca.TNodeTemplate;
 import org.eclipse.winery.model.tosca.TNodeType;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.TOSCAAnalyzer;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.Constants;
+import org.eclipse.winery.repository.completion.analyzer.TOSCAAnalyzer;
+import org.eclipse.winery.repository.completion.helper.Constants;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/topologycompletion/CompletionManager.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/topologycompletion/CompletionManager.java
@@ -12,17 +12,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion;
+package org.eclipse.winery.repository.completion.topologycompletion;
 
 import org.eclipse.winery.model.tosca.*;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.DeferredAnalyzer;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.PlaceHolderAnalyzer;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.RequirementAnalyzer;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.TOSCAAnalyzer;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion.completer.DeferredCompleter;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion.completer.PlaceHolderCompleter;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion.completer.RequirementCompleter;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion.completer.StepByStepCompleter;
+import org.eclipse.winery.repository.completion.analyzer.DeferredAnalyzer;
+import org.eclipse.winery.repository.completion.analyzer.PlaceHolderAnalyzer;
+import org.eclipse.winery.repository.completion.analyzer.RequirementAnalyzer;
+import org.eclipse.winery.repository.completion.analyzer.TOSCAAnalyzer;
+import org.eclipse.winery.repository.completion.topologycompletion.completer.DeferredCompleter;
+import org.eclipse.winery.repository.completion.topologycompletion.completer.PlaceHolderCompleter;
+import org.eclipse.winery.repository.completion.topologycompletion.completer.RequirementCompleter;
+import org.eclipse.winery.repository.completion.topologycompletion.completer.StepByStepCompleter;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/topologycompletion/completer/DeferredCompleter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/topologycompletion/completer/DeferredCompleter.java
@@ -12,13 +12,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion.completer;
+package org.eclipse.winery.repository.completion.topologycompletion.completer;
 
 import org.eclipse.winery.model.tosca.*;
 import org.eclipse.winery.model.tosca.utils.ModelUtilities;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.TOSCAAnalyzer;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.NodeTemplateConnector;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.Utils;
+import org.eclipse.winery.repository.completion.analyzer.TOSCAAnalyzer;
+import org.eclipse.winery.repository.completion.helper.NodeTemplateConnector;
+import org.eclipse.winery.repository.completion.helper.Utils;
 
 import java.util.*;
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/topologycompletion/completer/PlaceHolderCompleter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/topologycompletion/completer/PlaceHolderCompleter.java
@@ -12,13 +12,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion.completer;
+package org.eclipse.winery.repository.completion.topologycompletion.completer;
 
 import org.eclipse.winery.model.tosca.*;
 import org.eclipse.winery.model.tosca.utils.ModelUtilities;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.TOSCAAnalyzer;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.NodeTemplateConnector;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.placeholderhandling.PlaceHolderHandler;
+import org.eclipse.winery.repository.completion.analyzer.TOSCAAnalyzer;
+import org.eclipse.winery.repository.completion.helper.NodeTemplateConnector;
+import org.eclipse.winery.repository.completion.placeholderhandling.PlaceHolderHandler;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/topologycompletion/completer/RequirementCompleter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/topologycompletion/completer/RequirementCompleter.java
@@ -12,13 +12,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion.completer;
+package org.eclipse.winery.repository.completion.topologycompletion.completer;
 
 import org.eclipse.winery.model.tosca.*;
 import org.eclipse.winery.model.tosca.utils.ModelUtilities;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.TOSCAAnalyzer;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.NodeTemplateConnector;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.Utils;
+import org.eclipse.winery.repository.completion.analyzer.TOSCAAnalyzer;
+import org.eclipse.winery.repository.completion.helper.NodeTemplateConnector;
+import org.eclipse.winery.repository.completion.helper.Utils;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/topologycompletion/completer/StepByStepCompleter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/topologycompletion/completer/StepByStepCompleter.java
@@ -12,14 +12,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
 
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion.completer;
+package org.eclipse.winery.repository.completion.topologycompletion.completer;
 
 import org.eclipse.winery.model.tosca.*;
 import org.eclipse.winery.model.tosca.utils.ModelUtilities;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.analyzer.TOSCAAnalyzer;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.NodeTemplateConnector;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.helper.Utils;
-import org.eclipse.winery.topologymodeler.addons.topologycompleter.placeholderhandling.PlaceHolderHandler;
+import org.eclipse.winery.repository.completion.analyzer.TOSCAAnalyzer;
+import org.eclipse.winery.repository.completion.helper.NodeTemplateConnector;
+import org.eclipse.winery.repository.completion.helper.Utils;
+import org.eclipse.winery.repository.completion.placeholderhandling.PlaceHolderHandler;
 
 import java.util.*;
 
@@ -56,7 +56,6 @@ public class StepByStepCompleter {
      * This method is called when a topology containing {@link TRequirement}s is completed step by step.
      *
      * @param unfulfilledRequirements a list of unfulfilled requirements
-     * @param placeHolders            a list of place holders to be fulfilled
      * @param toscaAnalyzer           the {@link TOSCAAnalyzer} object to access the data model
      */
     public void completeTopologyStepByStep(Map<TRequirement, TNodeTemplate> unfulfilledRequirements, TOSCAAnalyzer toscaAnalyzer) {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/topologycompletion/completer/package-info.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/topologycompletion/completer/package-info.java
@@ -15,5 +15,5 @@
 /**
  * This package contains classes and methods to actually execute the completion for several use cases.
  */
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion.completer;
+package org.eclipse.winery.repository.completion.topologycompletion.completer;
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/topologycompletion/package-info.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/completion/topologycompletion/package-info.java
@@ -15,5 +15,5 @@
 /**
  * This package contains classes and methods to execute and manage the completion.
  */
-package org.eclipse.winery.topologymodeler.addons.topologycompleter.topologycompletion;
+package org.eclipse.winery.repository.completion.topologycompletion;
 

--- a/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/completion/topologycompletion/CompletionInterfaceTest.java
+++ b/org.eclipse.winery.repository/src/test/java/org/eclipse/winery/repository/completion/topologycompletion/CompletionInterfaceTest.java
@@ -1,0 +1,15 @@
+package org.eclipse.winery.repository.completion.topologycompletion;
+
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.winery.repository.TestWithGitBackedRepository;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CompletionInterfaceTest extends TestWithGitBackedRepository {
+
+    @Test
+    public void complete() throws GitAPIException {
+        this.setRevisionTo("origin/plain");
+    }
+}


### PR DESCRIPTION
The "old" topology modeler had the feature of topology completion (http://eclipse.github.io/winery/user/TopologyCompletion). This has to be ported to the new architecture. This PR tracks the progress.

This also does req/cap matching and contains algorithms not published anywhere.

Code written by @hirmerpl. Needs to be completed.