### PR TITLE
Not all JAXB Providers support Namespace Prefixing

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/JAXBSupport.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/JAXBSupport.java
@@ -16,6 +16,7 @@ package org.eclipse.winery.repository;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
+import javax.xml.bind.PropertyException;
 import javax.xml.bind.Unmarshaller;
 
 import org.eclipse.winery.model.selfservice.Application;
@@ -113,7 +114,11 @@ public class JAXBSupport {
             m = JAXBSupport.context.createMarshaller();
             // pretty printed output is required as the XML is sent 1:1 to the browser for editing
             m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-            m.setProperty("com.sun.xml.bind.namespacePrefixMapper", JAXBSupport.prefixMapper);
+            try {
+                m.setProperty("com.sun.xml.bind.namespacePrefixMapper", JAXBSupport.prefixMapper);
+            } catch (PropertyException e) {
+                // Namespace-Prefixing is not supported by the used Provider. Nothing we can do about that
+            }
             if (!includeProcessingInstruction) {
                 // side effect of JAXB_FRAGMENT property (when true): processing instruction is not included
                 m.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);


### PR DESCRIPTION
Monkey-Patch JAXB Providers not supporting NamespacePrefixing

This avoids killing the container when importing a Csar (through CsarImporter) without namespace-prefixing on the classpath. Ideally the technical debt of depending on com.sun.xml.bind:jaxb-impl:2.2.5 should at some point be adressed by switching to org.glassfish.jaxb:jaxb-runtime:*. That is somewhat out of scope here and would introduce a CDDL 1.1 / GPL 2.0 (wCPE) dependency.

Signed-off-by: Clemens Lieb <vogel612@gmx.de>