### PR TITLE
[WIP] First step to add logging in the browser

### DIFF
--- a/org.eclipse.winery.repository.rest/pom.xml
+++ b/org.eclipse.winery.repository.rest/pom.xml
@@ -35,6 +35,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.alexvictoor</groupId>
+            <artifactId>web-logback</artifactId>
+            <version>0.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
             <version>${org.slf4j}</version>

--- a/org.eclipse.winery.repository.rest/src/main/resources/logback.xml
+++ b/org.eclipse.winery.repository.rest/src/main/resources/logback.xml
@@ -15,15 +15,27 @@
 
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36}:%line %method - %msg%n</pattern>
         </encoder>
+    </appender>
+    <appender name="WEBOUT" class="com.github.alexvictoor.weblogback.BrowserConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36}:%line %method - %msg%n</pattern>
+        </encoder>
+        <port>8765</port> <!-- Optional, this is the port on which the HTTP SSE server will listen. Default port is 8765 -->
+        <active>true</active> <!-- Optional, if false the appender is disabled. Default value is true -->
+        <buffer>1</buffer> <!-- Optional, the size of a replay buffer for late joiners that will receive already emmited messages -->
     </appender>
 
     <logger name="org.eclipse.winery" level="DEBUG"/>
     <logger name="org.apache.catalina.core.ApplicationDispatcher" level="SEVERE"/>
 
-    <root level="info">
+    <root level="TRACE">
         <appender-ref ref="STDOUT"/>
+        <appender-ref ref="WEBOUT"/>
     </root>
 </configuration>

--- a/org.eclipse.winery.repository.rest/src/main/webapp/WEB-INF/web.xml
+++ b/org.eclipse.winery.repository.rest/src/main/webapp/WEB-INF/web.xml
@@ -30,6 +30,10 @@
         </init-param>
         <load-on-startup>2</load-on-startup>
     </servlet>
+    <servlet>
+        <servlet-name>ViewStatusMessages</servlet-name>
+        <servlet-class>ch.qos.logback.classic.ViewStatusMessagesServlet</servlet-class>
+    </servlet>
 
     <filter>
         <filter-name>CorsFilter</filter-name>
@@ -101,6 +105,15 @@
         <filter-name>CorsFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
+
+    <servlet-mapping>
+        <servlet-name>ViewStatusMessages</servlet-name>
+        <!-- 
+            The documentation proposes lbClassicStatus (see https://logback.qos.ch/manual/configuration.html).
+            We do security by obscurity by using another URL pattern
+          -->
+        <url-pattern>/logback-classic-status</url-pattern>
+    </servlet-mapping>
 
     <servlet-mapping>
         <servlet-name>WineryResources</servlet-name>

--- a/org.eclipse.winery.repository.ui/src/index.html
+++ b/org.eclipse.winery.repository.ui/src/index.html
@@ -22,6 +22,14 @@
 </head>
 
 <body>
+<script>
+    var s = document.createElement("script");
+    s.setAttribute("type", "text/javascript");
+    s.setAttribute("src", "http://" + window.location.hostname + ":8765/logback.js");
+    var nodes = document.getElementsByTagName("*");
+    var node = nodes[nodes.length -1].parentNode;
+    node.appendChild(s);
+</script>
 <winery-repository>
     <div class="loader"></div>
 </winery-repository>


### PR DESCRIPTION
By using https://github.com/alexvictoor/web-logback, we can view logback output in the the browser. With the current angular setup, the lib cannot be used as is - the javascript part needs to be adapted: The URL of the server is NOT injected into the js by the server, but read from the URL. However, the script gets `vendor.js` instead of `liveload.js`.

![grafik](https://user-images.githubusercontent.com/1366654/42499249-979eaed8-842e-11e8-84f9-5e3151ca0f01.png)
