### PR TITLE
Add Provenance to the OSGI-Exported modules

### DIFF
--- a/org.eclipse.winery.provenance/pom.xml
+++ b/org.eclipse.winery.provenance/pom.xml
@@ -32,6 +32,8 @@
     </distributionManagement>
     <properties>
         <checkstyle.config.location>../checkstyle.xml</checkstyle.config.location>
+        <!-- property is required for deployment to mvn-repo -->
+        <main.basedir>${project.parent.basedir}</main.basedir>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -368,6 +368,13 @@
                                                 <source>true</source>
                                                 <transitive>false</transitive>
                                             </artifact>
+                                            <artifact>
+                                                <id>
+                                                    org.eclipse.winery:org.eclipse.winery.provenance:2.0.0-SNAPSHOT
+                                                </id>
+                                                <source>true</source>
+                                                <transitive>false</transitive>
+                                            </artifact>
                                         </artifacts>
                                     </feature>
                                 </featureDefinitions>


### PR DESCRIPTION
Provenance classes are used in the public API for CsarImporter.

Any consumers of CsarImporter must also have access to `org.eclipse.winery.provenance.exceptions`. This applies for OSGI consumers and maven consumers alike. As such we need to export the provenance module for both consumption strategies

Signed-off-by: Clemens Lieb <vogel612@gmx.de>
