### PR TITLE
Fix/osgi slf4j issues

### DIFF
--- a/org.eclipse.winery.repository.rest/pom.xml
+++ b/org.eclipse.winery.repository.rest/pom.xml
@@ -222,19 +222,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-ext</artifactId>
-            <version>${org.slf4j}</version>
-            <scope>compile</scope>
-            <!-- not approved by Eclipse legal -->
-            <exclusions>
-                <exclusion>
-                    <groupId>ch.qos.cal10n</groupId>
-                    <artifactId>cal10n-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
             <version>${org.apache.commons.configuration}</version>

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/RestUtils.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/RestUtils.java
@@ -104,8 +104,8 @@ import com.sun.jersey.core.header.ContentDisposition;
 import com.sun.jersey.core.header.FormDataContentDisposition;
 import com.sun.jersey.multipart.FormDataBodyPart;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.slf4j.ext.XLogger;
-import org.slf4j.ext.XLoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Contains utility functionality concerning with everything that is <em>not</em> related only to the repository, but
@@ -114,7 +114,7 @@ import org.slf4j.ext.XLoggerFactory;
  */
 public class RestUtils {
 
-    private static final XLogger LOGGER = XLoggerFactory.getXLogger(RestUtils.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RestUtils.class);
 
     // RegExp inspired by http://stackoverflow.com/a/5396246/873282
     // NameStartChar without ":"

--- a/org.eclipse.winery.repository/pom.xml
+++ b/org.eclipse.winery.repository/pom.xml
@@ -100,19 +100,6 @@
             <version>2.7.7</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-ext</artifactId>
-            <version>${org.slf4j}</version>
-            <scope>compile</scope>
-            <!-- not approved by Eclipse legal -->
-            <exclusions>
-                <exclusion>
-                    <groupId>ch.qos.cal10n</groupId>
-                    <artifactId>cal10n-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.winery</groupId>
             <artifactId>org.eclipse.winery.common</artifactId>
             <version>2.0.0-SNAPSHOT</version>

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/BackendUtils.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/BackendUtils.java
@@ -159,8 +159,8 @@ import org.apache.xerces.xs.XSTerm;
 import org.apache.xerces.xs.XSTypeDefinition;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.slf4j.ext.XLogger;
-import org.slf4j.ext.XLoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.ls.LSInput;
@@ -182,7 +182,7 @@ public class BackendUtils {
      */
     public static final ObjectMapper mapper = getObjectMapper();
 
-    private static final XLogger LOGGER = XLoggerFactory.getXLogger(BackendUtils.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BackendUtils.class);
 
     private static final MediaType MEDIATYPE_APPLICATION_OCTET_STREAM = MediaType.parse("application/octet-stream");
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/xsd/RepositoryBasedXsdImportManager.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/xsd/RepositoryBasedXsdImportManager.java
@@ -29,8 +29,8 @@ import org.eclipse.winery.repository.backend.BackendUtils;
 import org.eclipse.winery.repository.backend.ImportUtils;
 import org.eclipse.winery.repository.backend.RepositoryFactory;
 import org.eclipse.winery.repository.backend.constants.MediaTypes;
-import org.slf4j.ext.XLogger;
-import org.slf4j.ext.XLoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
 
 public class RepositoryBasedXsdImportManager implements XsdImportManager {
 
-    private static final XLogger LOGGER = XLoggerFactory.getXLogger(BackendUtils.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BackendUtils.class);
 
     /**
      * Finds out all imports belonging to the given namespace

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/ToscaExportUtil.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/ToscaExportUtil.java
@@ -62,13 +62,13 @@ import org.eclipse.winery.repository.datatypes.ids.elements.DirectoryId;
 import org.eclipse.winery.repository.datatypes.ids.elements.VisualAppearanceId;
 import org.eclipse.winery.repository.exceptions.RepositoryCorruptException;
 
-import org.slf4j.ext.XLogger;
-import org.slf4j.ext.XLoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 
 public class ToscaExportUtil {
 
-    private static final XLogger LOGGER = XLoggerFactory.getXLogger(ToscaExportUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ToscaExportUtil.class);
 
     /*
      * these two are GLOBAL VARIABLES leading to the fact that this class has to

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <checkstyle.config.location>checkstyle.xml</checkstyle.config.location>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.version.osgi>2.0.0</project.version.osgi>
 
         <!-- versions of all used libraries -->
         <ch.qos.logback.logback-classic.version>1.2.3</ch.qos.logback.logback-classic.version>
@@ -267,183 +268,262 @@
                                         <artifacts>
                                             <artifact>
                                                 <id>
-                                                    org.eclipse.winery:org.eclipse.winery.model.bpmn4tosca:2.0.0-SNAPSHOT
+                                                    org.eclipse.winery:org.eclipse.winery.model.bpmn4tosca:${project.version}
                                                 </id>
                                                 <source>true</source>
-                                                <transitive>false</transitive>
+                                                <transitive>true</transitive>
+                                                <excludes>
+                                                    <exclude>org.eclipse.winery::</exclude>
+                                                </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.bpmn2bpel.model.*;-noimport:=true</Export-Package>
+                                                    <Export-Package>org.eclipse.winery.bpmn2bpel.model.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
                                                 </instructions>
                                             </artifact>
                                             <artifact>
                                                 <id>
-                                                    org.eclipse.winery:org.eclipse.winery.model.csar.toscametafile:2.0.0-SNAPSHOT
+                                                    org.eclipse.winery:org.eclipse.winery.model.csar.toscametafile:${project.version}
                                                 </id>
                                                 <source>true</source>
-                                                <transitive>false</transitive>
+                                                <transitive>true</transitive>
+                                                <excludes>
+                                                    <exclude>org.eclipse.winery::</exclude>
+                                                </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.model.csar.toscametafile.*;-noimport:=true</Export-Package>
+                                                    <Export-Package>org.eclipse.winery.model.csar.toscametafile.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
                                                 </instructions>
                                             </artifact>
                                             <artifact>
                                                 <id>
-                                                    org.eclipse.winery:org.eclipse.winery.model.selfservice:2.0.0-SNAPSHOT
+                                                    org.eclipse.winery:org.eclipse.winery.model.selfservice:${project.version}
                                                 </id>
                                                 <source>true</source>
-                                                <transitive>false</transitive>
+                                                <transitive>true</transitive>
+                                                <excludes>
+                                                    <exclude>org.eclipse.winery::</exclude>
+                                                </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.model.selfservice.*;-noimport:=true</Export-Package>
+                                                    <Export-Package>org.eclipse.winery.model.selfservice.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
                                                 </instructions>
                                             </artifact>
                                             <artifact>
-                                                <id>org.eclipse.winery:org.eclipse.winery.model.tosca:2.0.0-SNAPSHOT
+                                                <id>org.eclipse.winery:org.eclipse.winery.model.tosca:${project.version}
                                                 </id>
                                                 <source>true</source>
-                                                <transitive>false</transitive>
+                                                <transitive>true</transitive>
+                                                <excludes>
+                                                    <exclude>org.eclipse.winery::</exclude>
+                                                </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.model.tosca.*;-noimport:=true</Export-Package>
+                                                    <Export-Package>org.eclipse.winery.model.tosca.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
                                                 </instructions>
                                             </artifact>
                                             <artifact>
                                                 <id>
-                                                    org.eclipse.winery:org.eclipse.winery.model.tosca.yaml:2.0.0-SNAPSHOT
+                                                    org.eclipse.winery:org.eclipse.winery.model.tosca.yaml:${project.version}
                                                 </id>
                                                 <source>true</source>
-                                                <transitive>false</transitive>
+                                                <transitive>true</transitive>
+                                                <excludes>
+                                                    <exclude>org.eclipse.winery::</exclude>
+                                                </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.model.tosca.yaml.*;-noimport:=true</Export-Package>
+                                                    <Export-Package>org.eclipse.winery.model.tosca.yaml.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
                                                 </instructions>
                                             </artifact>
                                             <artifact>
-                                                <id>org.eclipse.winery:org.eclipse.winery.common:2.0.0-SNAPSHOT</id>
+                                                <id>org.eclipse.winery:org.eclipse.winery.common:${project.version}</id>
                                                 <source>true</source>
-                                                <transitive>false</transitive>
+                                                <transitive>true</transitive>
+                                                <excludes>
+                                                    <exclude>org.eclipse.winery::</exclude>
+                                                    <!-- Export-Package specification is incorrect, 
+                                                         see https://github.com/SQiShER/java-object-diff/issues/205 -->
+                                                    <exclude>de.danielbechler:java-object-diff:${de.danielbechler.java-object-diff}</exclude>
+                                                </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.common.*;-noimport:=true</Export-Package>
+                                                    <Export-Package>org.eclipse.winery.common.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
                                                 </instructions>
                                             </artifact>
                                             <artifact>
-                                                <id>org.eclipse.winery:org.eclipse.winery.yaml.common:2.0.0-SNAPSHOT
+                                                <id>org.eclipse.winery:org.eclipse.winery.yaml.common:${project.version}
                                                 </id>
                                                 <source>true</source>
-                                                <transitive>false</transitive>
+                                                <transitive>true</transitive>
+                                                <excludes>
+                                                    <exclude>org.eclipse.winery::</exclude>
+                                                </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.yaml.common.*;-noimport:=true</Export-Package>
+                                                    <Export-Package>org.eclipse.winery.yaml.common.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
                                                 </instructions>
                                             </artifact>
                                             <artifact>
                                                 <id>
-                                                    org.eclipse.winery:org.eclipse.winery.yaml.converter:2.0.0-SNAPSHOT
+                                                    org.eclipse.winery:org.eclipse.winery.yaml.converter:${project.version}
                                                 </id>
                                                 <source>true</source>
-                                                <transitive>false</transitive>
+                                                <transitive>true</transitive>
+                                                <excludes>
+                                                    <exclude>org.eclipse.winery::</exclude>
+                                                </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.yaml.converter.*;-noimport:=true</Export-Package>
-                                                </instructions>
-                                            </artifact>
-                                            <artifact>
-                                                <id>org.eclipse.winery:org.eclipse.winery.cli:2.0.0-SNAPSHOT</id>
-                                                <source>true</source>
-                                                <transitive>false</transitive>
-                                                <instructions>
-                                                    <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.cli.*;-noimport:=true</Export-Package>
+                                                    <Export-Package>org.eclipse.winery.yaml.converter.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
                                                 </instructions>
                                             </artifact>
                                             <artifact>
                                                 <id>
-                                                    org.eclipse.winery:org.eclipse.winery.bpmn4tosca.converter.tobpel:2.0.0-SNAPSHOT
+                                                    org.eclipse.winery:org.eclipse.winery.bpmn4tosca.converter.tobpel:${project.version}
                                                 </id>
                                                 <source>true</source>
-                                                <transitive>false</transitive>
+                                                <transitive>true</transitive>
+                                                <excludes>
+                                                    <exclude>org.eclipse.winery::</exclude>
+                                                </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.bpmn2bpel.*;-noimport:=true</Export-Package>
+                                                    <Export-Package>org.eclipse.winery.bpmn2bpel.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
                                                 </instructions>
                                             </artifact>
                                             <artifact>
-                                                <id>org.eclipse.winery:org.eclipse.winery.repository:2.0.0-SNAPSHOT</id>
+                                                <id>org.eclipse.winery:org.eclipse.winery.repository:${project.version}</id>
                                                 <source>true</source>
                                                 <excludes>
-                                                    <exclude>org.slf4j:::</exclude>
-                                                    <exclude>org.eclipse.collections:eclipse-collections*::</exclude>
+                                                    <exclude>org.eclipse.winery:::</exclude>
                                                 </excludes>
                                                 <transitive>true</transitive>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.repository.*;-noimport:=true</Export-Package>
+                                                    <Export-Package>org.eclipse.winery.repository.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
                                                 </instructions>
                                             </artifact>
                                             <artifact>
                                                 <id>
-                                                    org.eclipse.winery:org.eclipse.winery.repository.client:2.0.0-SNAPSHOT
+                                                    org.eclipse.winery:org.eclipse.winery.repository.client:${project.version}
                                                 </id>
                                                 <source>true</source>
-                                                <transitive>false</transitive>
+                                                <transitive>true</transitive>
+                                                <excludes>
+                                                    <exclude>org.eclipse.winery::</exclude>
+                                                </excludes>
                                                 <instructions>
-                                                    <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.repository.client.*;-noimport:=true</Export-Package>
+                                                    <Import-Package>
+                                                        !com.sun.org.apache.xalan.*,
+                                                        *;resolution:=optional
+                                                    </Import-Package>
+                                                    <Export-Package>org.eclipse.winery.repository.client.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
                                                 </instructions>
                                             </artifact>
                                             <artifact>
                                                 <id>
-                                                    org.eclipse.winery:org.eclipse.winery.repository.configuration:2.0.0-SNAPSHOT
+                                                    org.eclipse.winery:org.eclipse.winery.repository.configuration:${project.version}
                                                 </id>
                                                 <source>true</source>
-                                                <transitive>false</transitive>
+                                                <transitive>true</transitive>
+                                                <excludes>
+                                                    <exclude>org.eclipse.winery::</exclude>
+                                                </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.repository.configuration.*;-noimport:=true</Export-Package>
+                                                    <Export-Package>org.eclipse.winery.repository.configuration.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
                                                 </instructions>
                                             </artifact>
                                             <artifact>
-                                                <id>org.eclipse.winery:org.eclipse.winery.compliance:2.0.0-SNAPSHOT</id>
+                                                <id>org.eclipse.winery:org.eclipse.winery.compliance:${project.version}</id>
                                                 <source>true</source>
-                                                <transitive>false</transitive>
+                                                <transitive>true</transitive>
+                                                <excludes>
+                                                    <exclude>org.eclipse.winery::</exclude>
+                                                </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.compliance.*;-noimport:=true</Export-Package>
+                                                    <Export-Package>org.eclipse.winery.compliance.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
                                                 </instructions>
                                             </artifact>
                                             <artifact>
-                                                <id>org.eclipse.winery:org.eclipse.winery.generators.ia:2.0.0-SNAPSHOT
-                                                </id>
+                                                <id>org.eclipse.winery:org.eclipse.winery.topologygraph:${project.version}</id>
                                                 <source>true</source>
-                                                <transitive>false</transitive>
+                                                <transitive>true</transitive>
+                                                <excludes>
+                                                    <exclude>org.eclipse.winery::</exclude>
+                                                </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.generators.ia.*;-noimport:=true</Export-Package>
+                                                    <Export-Package>org.eclipse.winery.topologygraph.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
+                                                </instructions>
+                                            </artifact>
+                                            <artifact>
+                                                <id>org.eclipse.winery:org.eclipse.winery.generators.ia:${project.version}
+                                                </id>
+                                                <source>true</source>
+                                                <transitive>true</transitive>
+                                                <excludes>
+                                                    <exclude>org.eclipse.winery::</exclude>
+                                                </excludes>
+                                                <instructions>
+                                                    <Import-Package>*;resolution:=optional</Import-Package>
+                                                    <Export-Package>org.eclipse.winery.generators.ia.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
                                                 </instructions>
                                             </artifact>
                                             <artifact>
                                                 <id>
-                                                    org.eclipse.winery:org.eclipse.winery.highlevelrestapi:2.0.0-SNAPSHOT
+                                                    org.eclipse.winery:org.eclipse.winery.highlevelrestapi:${project.version}
                                                 </id>
                                                 <source>true</source>
-                                                <transitive>false</transitive>
+                                                <transitive>true</transitive>
+                                                <excludes>
+                                                    <exclude>org.eclipse.winery::</exclude>
+                                                </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.highlevelrestapi.*;-noimport:=true</Export-Package>
+                                                    <Export-Package>org.eclipse.winery.highlevelrestapi.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
                                                 </instructions>
                                             </artifact>
                                             <artifact>
                                                 <id>
-                                                    org.eclipse.winery:org.eclipse.winery.provenance:2.0.0-SNAPSHOT
+                                                    org.eclipse.winery:org.eclipse.winery.provenance:${project.version}
                                                 </id>
                                                 <source>true</source>
-                                                <transitive>false</transitive>
+                                                <transitive>true</transitive>
+                                                <excludes>
+                                                    <exclude>org.eclipse.winery::</exclude>
+                                                </excludes>
                                                 <instructions>
                                                     <Import-Package>*;resolution:=optional</Import-Package>
-                                                    <Export-Package>org.eclipse.winery.provenance.*;-noimport:=true</Export-Package>
+                                                    <Export-Package>org.eclipse.winery.provenance.*;-noimport:=true;version:=${project.version.osgi}</Export-Package>
                                                 </instructions>
+                                            </artifact>
+                                            <!-- 
+                                                SECTION: Special artifact imports that fix some failed dependency chains
+                                             -->
+                                            
+                                            <artifact>
+                                                <id>com.diffplug.osgi:com.diffplug.osgi.extension.sun.misc:0.0.0</id>
+                                            </artifact>
+                                            <!-- Sidesteps the incorrect export, should be fixed with 0.96 -->
+                                            <artifact>
+                                                <id>de.danielbechler:java-object-diff:${de.danielbechler.java-object-diff}</id>
+                                                <source>true</source>
+                                                <transitive>true</transitive>
+                                                <override>true</override>
+                                                <instructions>
+                                                    <!-- BundleVendor and BundleDocs are copied from official github repo -->
+                                                    <Bundle-Vendor>Daniel Bechler</Bundle-Vendor>
+                                                    <Bundle-DocURL>https://github.com/SQiShER/java-object-diff</Bundle-DocURL>
+                                                    <Import-Package>*;resolution:=optional</Import-Package>
+                                                    <Export-Package>de.danielbechler.diff.*;-noimport:=true</Export-Package>
+                                                </instructions>
+                                            </artifact>
+                                            <artifact>
+                                                <id>org.slf4j:jul-to-slf4j:${org.slf4j}</id>
+                                                <source>true</source>
+                                                <transitive>true</transitive>
                                             </artifact>
                                         </artifacts>
                                     </feature>


### PR DESCRIPTION
Removed slf4j-ext from winery, replacing usages of XLogger with usages of Logger.
Also explicitly export slf4j dependencies to OSGi consumers in the version used in winery.

Additional fixes include corrections to some incorrect MANIFEST.MF files (de.danielbechler:java-object-diff).  
This fixes the remainder of issues encountered with OSGi

Reviews are highly appreciated.
