### PR TITLE
Enable FileBasedRepository imports through CsarImporter

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/RepositoryFactory.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/RepositoryFactory.java
@@ -59,7 +59,7 @@ public class RepositoryFactory {
         }
     }
 
-    private static void reconfigure(FileBasedRepositoryConfiguration fileBasedRepositoryConfiguration) {
+    public static void reconfigure(FileBasedRepositoryConfiguration fileBasedRepositoryConfiguration) {
         RepositoryFactory.fileBasedRepositoryConfiguration = fileBasedRepositoryConfiguration;
         RepositoryFactory.gitBasedRepositoryConfiguration = null;
 


### PR DESCRIPTION
The capability to import CSARs to a FileBasedRepository without git support is crucial to the introduction of the winery model into the container, cf. OpenTOSCA/container#78.

Notably for correct processing, validation and other purposes, CSARs within the container need to be segregated, which is only possible if the storage locations are different. Since the CsarImporter does not expose an overload that allows specifying the target repository, the RepositoryFactory needs to be reconfigured to take a specific FileBasedRepositoryConfiguration.