### PR TITLE
Fix conversion of coordinates for Node Templates

### DIFF
--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TNodeTemplate.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TNodeTemplate.java
@@ -13,8 +13,19 @@
  *******************************************************************************/
 package org.eclipse.winery.model.tosca.yaml;
 
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
+
 import org.eclipse.winery.model.tosca.yaml.support.Metadata;
 import org.eclipse.winery.model.tosca.yaml.support.TMapRequirementAssignment;
 import org.eclipse.winery.model.tosca.yaml.visitor.AbstractParameter;
@@ -22,12 +33,8 @@ import org.eclipse.winery.model.tosca.yaml.visitor.AbstractResult;
 import org.eclipse.winery.model.tosca.yaml.visitor.IVisitor;
 import org.eclipse.winery.model.tosca.yaml.visitor.VisitorNode;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.namespace.QName;
-import java.util.*;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "tNodeTemplate", namespace = " http://docs.oasis-open.org/tosca/ns/simple/yaml/1.0", propOrder = {

--- a/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TNodeTemplate.java
+++ b/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/TNodeTemplate.java
@@ -289,7 +289,9 @@ public class TNodeTemplate implements VisitorNode {
         }
 
         public Builder setMetadata(Metadata metadata) {
-            this.metadata = metadata;
+            if (Objects.nonNull(metadata) && !metadata.isEmpty()) {
+                this.metadata = metadata;
+            }
             return this;
         }
 

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TExtensibleElements.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TExtensibleElements.java
@@ -69,7 +69,7 @@ public abstract class TExtensibleElements implements Serializable {
 
     @XmlAnyAttribute
     @NonNull
-    private Map<QName, String> otherAttributes = new HashMap<QName, String>();
+    private Map<QName, String> otherAttributes = new HashMap<>();
 
     public TExtensibleElements() {
     }

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TNodeTemplate.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TNodeTemplate.java
@@ -64,8 +64,8 @@ public class TNodeTemplate extends RelationshipSourceOrTarget implements HasPoli
     @XmlAttribute(name = "minInstances")
     protected Integer minInstances;
     @XmlAttribute(name = "maxInstances")
-    protected String maxInstances;    
-    
+    protected String maxInstances;
+
     public TNodeTemplate() {
         super();
     }
@@ -325,7 +325,7 @@ public class TNodeTemplate extends RelationshipSourceOrTarget implements HasPoli
         private Integer minInstances;
         private String maxInstances;
         private String x;
-        private String y;        
+        private String y;
 
         public Builder(String id, QName type) {
             super(id, type);
@@ -336,7 +336,7 @@ public class TNodeTemplate extends RelationshipSourceOrTarget implements HasPoli
         }
 
         public Builder setRequirements(TNodeTemplate.Requirements requirements) {
-            this.requirements = requirements;            
+            this.requirements = requirements;
             return this;
         }
 

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TNodeTemplate.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/TNodeTemplate.java
@@ -64,8 +64,8 @@ public class TNodeTemplate extends RelationshipSourceOrTarget implements HasPoli
     @XmlAttribute(name = "minInstances")
     protected Integer minInstances;
     @XmlAttribute(name = "maxInstances")
-    protected String maxInstances;
-
+    protected String maxInstances;    
+    
     public TNodeTemplate() {
         super();
     }
@@ -83,6 +83,8 @@ public class TNodeTemplate extends RelationshipSourceOrTarget implements HasPoli
         this.name = builder.name;
         this.minInstances = builder.minInstances;
         this.maxInstances = builder.maxInstances;
+        this.setX(builder.x);
+        this.setY(builder.y);
     }
 
     @Override
@@ -322,6 +324,8 @@ public class TNodeTemplate extends RelationshipSourceOrTarget implements HasPoli
         private String name;
         private Integer minInstances;
         private String maxInstances;
+        private String x;
+        private String y;        
 
         public Builder(String id, QName type) {
             super(id, type);
@@ -332,7 +336,7 @@ public class TNodeTemplate extends RelationshipSourceOrTarget implements HasPoli
         }
 
         public Builder setRequirements(TNodeTemplate.Requirements requirements) {
-            this.requirements = requirements;
+            this.requirements = requirements;            
             return this;
         }
 
@@ -363,6 +367,16 @@ public class TNodeTemplate extends RelationshipSourceOrTarget implements HasPoli
 
         public Builder setMaxInstances(String maxInstances) {
             this.maxInstances = maxInstances;
+            return this;
+        }
+
+        public Builder setX(String x) {
+            this.x = x;
+            return this;
+        }
+
+        public Builder setY(String y) {
+            this.y = y;
             return this;
         }
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/converter/X2YConverter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/converter/X2YConverter.java
@@ -225,8 +225,8 @@ public class X2YConverter {
         if (Objects.nonNull(node.getX()) && Objects.nonNull(node.getY())) {
             meta.add(org.eclipse.winery.repository.backend.filebased.converter.support.Defaults.X_COORD, node.getX());
             meta.add(org.eclipse.winery.repository.backend.filebased.converter.support.Defaults.Y_COORD, node.getY());
-        }           
-            
+        }
+
         return Collections.singletonMap(
             node.getIdFromIdOrNameField(),
             new TNodeTemplate.Builder(

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/converter/X2YConverter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/converter/X2YConverter.java
@@ -218,7 +218,15 @@ public class X2YConverter {
 
     @NonNull
     public Map<String, TNodeTemplate> convert(org.eclipse.winery.model.tosca.TNodeTemplate node, @NonNull List<org.eclipse.winery.model.tosca.TRelationshipTemplate> rTs) {
-        if (Objects.isNull(node)) return new LinkedHashMap<>();
+        if (Objects.isNull(node)) {
+            return new LinkedHashMap<>();
+        }
+        Metadata meta = new Metadata();
+        if (Objects.nonNull(node.getX()) && Objects.nonNull(node.getY())) {
+            meta.add(org.eclipse.winery.repository.backend.filebased.converter.support.Defaults.X_COORD, node.getX());
+            meta.add(org.eclipse.winery.repository.backend.filebased.converter.support.Defaults.Y_COORD, node.getY());
+        }           
+            
         return Collections.singletonMap(
             node.getIdFromIdOrNameField(),
             new TNodeTemplate.Builder(
@@ -227,6 +235,7 @@ public class X2YConverter {
                     new NodeTypeId(node.getType())
                 ))
                 .setProperties(convert(node, node.getProperties()))
+                .setMetadata(meta)
                 .setRequirements(convert(node.getRequirements()))
                 .addRequirements(rTs.stream()
                     .filter(entry -> Objects.nonNull(entry.getSourceElement()) && entry.getSourceElement().getRef().equals(node))

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/converter/Y2XConverter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/converter/Y2XConverter.java
@@ -558,7 +558,7 @@ public class Y2XConverter {
         if (Objects.isNull(node)) {
             return null;
         }
-        
+
         TNodeTemplate.Builder builder = new TNodeTemplate.Builder(id, node.getType())
             .addDocumentation(node.getDescription())
             .addDocumentation(node.getMetadata())
@@ -571,7 +571,7 @@ public class Y2XConverter {
             .setDeploymentArtifacts(convertDeploymentArtifacts(node.getArtifacts()));
         TNodeTemplate nodeTemplate = builder.build();
         this.nodeTemplateMap.put(id, nodeTemplate);
-        
+
         return nodeTemplate;
     }
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/converter/Y2XConverter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/converter/Y2XConverter.java
@@ -78,6 +78,7 @@ import org.eclipse.winery.model.tosca.yaml.TRequirementAssignment;
 import org.eclipse.winery.model.tosca.yaml.TTopologyTemplateDefinition;
 import org.eclipse.winery.model.tosca.yaml.support.Metadata;
 import org.eclipse.winery.model.tosca.yaml.support.TMapRequirementAssignment;
+import org.eclipse.winery.repository.backend.filebased.converter.support.Defaults;
 import org.eclipse.winery.repository.backend.filebased.converter.support.Namespaces;
 import org.eclipse.winery.repository.backend.filebased.converter.support.yaml.AssignmentBuilder;
 import org.eclipse.winery.repository.backend.filebased.converter.support.yaml.TypeConverter;
@@ -554,17 +555,23 @@ public class Y2XConverter {
      * @return TOSCA XML NodeTemplate
      */
     private TNodeTemplate convert(org.eclipse.winery.model.tosca.yaml.TNodeTemplate node, String id) {
-        if (Objects.isNull(node)) return null;
+        if (Objects.isNull(node)) {
+            return null;
+        }
+        
         TNodeTemplate.Builder builder = new TNodeTemplate.Builder(id, node.getType())
             .addDocumentation(node.getDescription())
             .addDocumentation(node.getMetadata())
             .setName(id)
+            .setX(node.getMetadata().getOrDefault(Defaults.X_COORD, "0"))
+            .setY(node.getMetadata().getOrDefault(Defaults.Y_COORD, "0"))
             .setProperties(convertPropertyAssignments(node.getProperties(), getPropertyTypeName(node.getType())))
             .addRequirements(convert(id, node.getRequirements()))
             .addCapabilities(convert(node.getCapabilities()))
             .setDeploymentArtifacts(convertDeploymentArtifacts(node.getArtifacts()));
         TNodeTemplate nodeTemplate = builder.build();
         this.nodeTemplateMap.put(id, nodeTemplate);
+        
         return nodeTemplate;
     }
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/converter/support/Defaults.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/converter/support/Defaults.java
@@ -100,5 +100,4 @@ public class Defaults {
 
     public static final String X_COORD = "x";
     public static final String Y_COORD = "y";
-
 }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/converter/support/Defaults.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/converter/support/Defaults.java
@@ -97,4 +97,8 @@ public class Defaults {
 
     public static final QName IMPLEMENTATION_ARTIFACTS = new QName(Namespaces.TOSCA_NS, "tosca.artifacts.Implementation");
     public static final QName DEPLOYMENT_ARTIFACTS = new QName(Namespaces.TOSCA_NS, "tosca.artifacts.Deployment");
+
+    public static final String X_COORD = "x";
+    public static final String Y_COORD = "y";
+
 }


### PR DESCRIPTION
Signed-off-by: Vladimir Yussupov <v.yussupov@gmail.com>

Add conversion of coordinates for correct representation of node templates in the topology.

- [ ] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request.
- [ ] Branch name checked. That means, the branch name starts with `thesis/`, `fix/`, ...
- [ ] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Ensure to use auto format in **all** files
- [ ] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
