### PR TITLE
Project/radon versioning button

### DIFF
--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentModule/addComponent.component.html
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentModule/addComponent.component.html
@@ -50,7 +50,8 @@
                         <br>
                         <div class="checkbox">
                             <label>
-                                <input name="versioning_checkbox" [checked]="useComponentVersion" (change)="onToggleUseVersion()" type="checkbox">
+                                <input name="versioning_checkbox" [checked]="useComponentVersion"
+                                       (change)="onToggleUseVersion()" type="checkbox">
                                 Enable Versioning
                             </label>
                         </div>
@@ -59,7 +60,8 @@
                                 <label for="newComponentVersion" class="control-label">Versioning:</label>
                                 <button type="button" class="btn btn-default btn-xs collapsebtn"
                                         (click)="collapseVersioning = !collapseVersioning" style="float: right;">
-                                    <span class="collapsespan" aria-hidden="true" [class.collapsed]="collapseVersioning"></span>
+                                    <span class="collapsespan" aria-hidden="true"
+                                          [class.collapsed]="collapseVersioning"></span>
                                 </button>
                             </div>
                             <div [collapse]="collapseVersioning">
@@ -81,19 +83,30 @@
                                     </div>
                                 </div>
                                 <p *ngIf="!hideHelp" class="help-block">
-                                    The <b>component version</b> specifies the components' external version defined by the creator of the
-                                    software (e.g., Apache Tomcat 8.5.1 has a component version <code>8.5.1</code>). Winery adds management
-                                    to the software which is versioned independently of the softwares' version. The version inside Winery is
-                                    called <b>management version</b> and is mandatory. It consists of a <b>winery version</b> and a <b>work
-                                    in progress (wip)</b> version. Upon the creation of a new component, both management versions are set
-                                    automatically with their initial values of 1. The generated name is displayed in the 'Final name' field
+                                    The <b>component version</b> specifies the components' external version defined by
+                                    the creator of the
+                                    software (e.g., Apache Tomcat 8.5.1 has a component version <code>8.5.1</code>).
+                                    Winery adds management
+                                    to the software which is versioned independently of the softwares' version. The
+                                    version inside Winery is
+                                    called <b>management version</b> and is mandatory. It consists of a <b>winery
+                                    version</b> and a <b>work
+                                    in progress (wip)</b> version. Upon the creation of a new component, both management
+                                    versions are set
+                                    automatically with their initial values of 1. The generated name is displayed in the
+                                    'Final name' field
                                     (e.g., the final id for Apache Tomcat 8.5.1 is <code>Tomcat_8.5.1-w1-wip1</code>).
                                     <br><br>
-                                    When developing a TOSCA definition, a the wip version is appended until the TOSCA definition is stable.
-                                    To test a TOSCA definition, the wip version can be committed. After a version was committed, a new
-                                    version must be added to apply further changes. Thus, a new wip version must be added (e.g.,
-                                    <code>Tomcat_8.5.1-w1-wip1</code> followed by <code>Tomcat_8.5.1-w1-wip2</code> released as
-                                    <code>Tomcat_8.5.1-w1</code> must be followed by <code>Tomcat_8.5.1-w2-wip1</code> to enable changes).
+                                    When developing a TOSCA definition, a the wip version is appended until the TOSCA
+                                    definition is stable.
+                                    To test a TOSCA definition, the wip version can be committed. After a version was
+                                    committed, a new
+                                    version must be added to apply further changes. Thus, a new wip version must be
+                                    added (e.g.,
+                                    <code>Tomcat_8.5.1-w1-wip1</code> followed by <code>Tomcat_8.5.1-w1-wip2</code>
+                                    released as
+                                    <code>Tomcat_8.5.1-w1</code> must be followed by <code>Tomcat_8.5.1-w2-wip1</code>
+                                    to enable changes).
                                     Thereby, different component versions do not affect each other (e.g., <code>Tomcat_8.5.1-w2-wip1</code>
                                     can be created while <code>Tomcat_9.0.1-w3</code> exists).
                                 </p>

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentModule/addComponent.component.html
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentModule/addComponent.component.html
@@ -48,14 +48,7 @@
                             </div>
                         </div>
                         <br>
-                        <div class="checkbox">
-                            <label>
-                                <input name="versioning_checkbox" [checked]="useComponentVersion"
-                                       (change)="onToggleUseVersion()" type="checkbox">
-                                Enable Versioning
-                            </label>
-                        </div>
-                        <div *ngIf="useComponentVersion">
+                        <div>
                             <div>
                                 <label for="newComponentVersion" class="control-label">Versioning:</label>
                                 <button type="button" class="btn btn-default btn-xs collapsebtn"
@@ -65,61 +58,66 @@
                                 </button>
                             </div>
                             <div [collapse]="collapseVersioning">
-                                <label for="newComponentVersion">
-                                    Component version
-                                </label>
-                                <i class="fa fa-question-circle" tooltip="click me" (click)="showHelp()"></i>
-                                <input type="text"
-                                       id="newComponentVersion"
-                                       name="newComponentVersion"
-                                       class="form-control"
-                                       #newVersion="ngModel"
-                                       (input)="onInputChange()"
-                                       [(ngModel)]="newComponentVersion.componentVersion">
-                                <div *ngIf="(newName.dirty || newName.touched) && validation?.noVersionProvidedWarning"
-                                     class="alert alert-warning">
-                                    <div>
-                                        You haven't provided a version!
-                                    </div>
+                                <div class="checkbox">
+                                    <label>
+                                        <input name="versioning_checkbox" [checked]="useComponentVersion"
+                                               (change)="onToggleUseVersion()" type="checkbox">
+                                        Enable Versioning
+                                    </label>
                                 </div>
-                                <p *ngIf="!hideHelp" class="help-block">
-                                    The <b>component version</b> specifies the components' external version defined by
-                                    the creator of the
-                                    software (e.g., Apache Tomcat 8.5.1 has a component version <code>8.5.1</code>).
-                                    Winery adds management
-                                    to the software which is versioned independently of the softwares' version. The
-                                    version inside Winery is
-                                    called <b>management version</b> and is mandatory. It consists of a <b>winery
-                                    version</b> and a <b>work
-                                    in progress (wip)</b> version. Upon the creation of a new component, both management
-                                    versions are set
-                                    automatically with their initial values of 1. The generated name is displayed in the
-                                    'Final name' field
-                                    (e.g., the final id for Apache Tomcat 8.5.1 is <code>Tomcat_8.5.1-w1-wip1</code>).
-                                    <br><br>
-                                    When developing a TOSCA definition, a the wip version is appended until the TOSCA
-                                    definition is stable.
-                                    To test a TOSCA definition, the wip version can be committed. After a version was
-                                    committed, a new
-                                    version must be added to apply further changes. Thus, a new wip version must be
-                                    added (e.g.,
-                                    <code>Tomcat_8.5.1-w1-wip1</code> followed by <code>Tomcat_8.5.1-w1-wip2</code>
-                                    released as
-                                    <code>Tomcat_8.5.1-w1</code> must be followed by <code>Tomcat_8.5.1-w2-wip1</code>
-                                    to enable changes).
-                                    Thereby, different component versions do not affect each other (e.g., <code>Tomcat_8.5.1-w2-wip1</code>
-                                    can be created while <code>Tomcat_9.0.1-w3</code> exists).
-                                </p>
-                                <div *ngIf="(validation?.noUnderscoresAllowed)
+                                <div *ngIf="useComponentVersion">
+                                    <label for="newComponentVersion" style="padding-right: 5px">
+                                        Component version
+                                    </label>
+                                    <i class="fa fa-question-circle" tooltip="click me" (click)="showHelp()"></i>
+                                    <input type="text"
+                                           id="newComponentVersion"
+                                           name="newComponentVersion"
+                                           class="form-control"
+                                           #newVersion="ngModel"
+                                           (input)="onInputChange()"
+                                           [(ngModel)]="newComponentVersion.componentVersion">
+                                    <div
+                                        *ngIf="(newName.dirty || newName.touched) && validation?.noVersionProvidedWarning"
+                                        class="alert alert-warning">
+                                        <div>
+                                            You haven't provided a version!
+                                        </div>
+                                    </div>
+                                    <p *ngIf="!hideHelp" class="help-block">
+                                        The <b>component version</b> specifies the components' external version defined
+                                        by the creator of the software (e.g., Apache Tomcat 8.5.1 has a component
+                                        version <code>8.5.1</code>). Winery adds management
+                                        to the software which is versioned independently of the softwares' version. The
+                                        version inside Winery is called <b>management version</b> and is mandatory. It
+                                        consists of a <b>winery version</b> and a <b>work in progress (wip)</b> version.
+                                        Upon the creation of a new component, both management versions are set
+                                        automatically with their initial values of 1. The generated name is displayed in
+                                        the 'Final name' field (e.g., the final id for Apache Tomcat 8.5.1 is <code>Tomcat_8.5.1-w1-wip1</code>).
+                                        <br><br>
+                                        When developing a TOSCA definition, a the wip version is appended until the
+                                        TOSCA definition is stable. To test a TOSCA definition, the wip version can be
+                                        committed. After a version was committed, a new version must be added to apply
+                                        further changes. Thus, a new wip version must be added (e.g., <code>Tomcat_8.5.1-w1-wip1</code>
+                                        followed by <code>Tomcat_8.5.1-w1-wip2</code> released as
+                                        <code>Tomcat_8.5.1-w1</code> must be followed by
+                                        <code>Tomcat_8.5.1-w2-wip1</code> to enable changes). Thereby, different
+                                        component versions do not affect each other (e.g.,
+                                        <code>Tomcat_8.5.1-w2-wip1</code> can be created while
+                                        <code>Tomcat_9.0.1-w3</code> exists).
+                                    </p>
+                                    <div *ngIf="(validation?.noUnderscoresAllowed)
                                     && (newVersion.dirty || newVersion.touched)"
-                                     class="alert alert-danger">
-                                    <div [hidden]="!validation?.noUnderscoresAllowed">
-                                        Underscores are not allowed in the version!<br>Please replace them with dashes.
+                                         class="alert alert-danger">
+                                        <div [hidden]="!validation?.noUnderscoresAllowed">
+                                            Underscores are not allowed in the version!<br>Please replace them with
+                                            dashes.
+                                        </div>
                                     </div>
+                                    <br>
+                                    <label for="finalName">Final name</label>
+                                    <code class="form-control" id="finalName">{{ newComponentFinalName }}</code>
                                 </div>
-                                <br>
-                                <label for="finalName">Final name</label>
-                                <code class="form-control" id="finalName">{{ newComponentFinalName }}</code>
                             </div>
                         </div>
                     </div>

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentModule/addComponent.component.html
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentModule/addComponent.component.html
@@ -48,7 +48,13 @@
                             </div>
                         </div>
                         <br>
-                        <div>
+                        <div class="checkbox">
+                            <label>
+                                <input name="versioning_checkbox" [checked]="useComponentVersion" (change)="onToggleUseVersion()" type="checkbox">
+                                Enable Versioning
+                            </label>
+                        </div>
+                        <div *ngIf="useComponentVersion">
                             <div>
                                 <label for="newComponentVersion" class="control-label">Versioning:</label>
                                 <button type="button" class="btn btn-default btn-xs collapsebtn"

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentModule/addComponent.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentModule/addComponent.component.ts
@@ -65,6 +65,8 @@ export class WineryAddComponent {
     newComponentFinalName: string;
     newComponentSelectedType: SelectData = new SelectData();
     newComponentVersion: WineryVersion = new WineryVersion('', 1, 1);
+    
+    useComponentVersion: boolean = true;
 
     validation: AddComponentValidation;
 
@@ -224,7 +226,10 @@ export class WineryAddComponent {
         }
 
         if (!isNullOrUndefined(this.newComponentFinalName) && this.newComponentFinalName.length > 0) {
-            this.newComponentFinalName += WineryVersion.WINERY_NAME_FROM_VERSION_SEPARATOR + this.newComponentVersion.toString();
+            if(this.useComponentVersion) {
+                this.newComponentFinalName += WineryVersion.WINERY_NAME_FROM_VERSION_SEPARATOR + this.newComponentVersion.toString();
+            }
+            
             const duplicate = this.componentData.find((component) => component.name.toLowerCase() === this.newComponentFinalName.toLowerCase());
 
             if (!isNullOrUndefined(duplicate)) {
@@ -243,7 +248,7 @@ export class WineryAddComponent {
             }
         }
 
-        if (this.newComponentVersion.componentVersion) {
+        if (this.newComponentVersion.componentVersion && this.useComponentVersion) {
             this.validation.noUnderscoresAllowed = this.newComponentVersion.componentVersion.includes('_');
             if (this.validation.noUnderscoresAllowed) {
                 return { noUnderscoresAllowed: true };
@@ -251,7 +256,12 @@ export class WineryAddComponent {
         }
 
         this.validation.noVersionProvidedWarning = isNullOrUndefined(this.newComponentVersion.componentVersion)
-            || this.newComponentVersion.componentVersion.length === 0;
+            || this.newComponentVersion.componentVersion.length === 0 || !this.useComponentVersion;
+    }
+    
+    onToggleUseVersion() {
+        this.useComponentVersion = !this.useComponentVersion;
+        this.onInputChange();
     }
 
     private handleComponentData(data: SectionData[]) {

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentModule/addComponent.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentModule/addComponent.component.ts
@@ -65,8 +65,8 @@ export class WineryAddComponent {
     newComponentFinalName: string;
     newComponentSelectedType: SelectData = new SelectData();
     newComponentVersion: WineryVersion = new WineryVersion('', 1, 1);
-    
-    useComponentVersion: boolean = true;
+
+    useComponentVersion = true;
 
     validation: AddComponentValidation;
 
@@ -226,10 +226,10 @@ export class WineryAddComponent {
         }
 
         if (!isNullOrUndefined(this.newComponentFinalName) && this.newComponentFinalName.length > 0) {
-            if(this.useComponentVersion) {
+            if (this.useComponentVersion) {
                 this.newComponentFinalName += WineryVersion.WINERY_NAME_FROM_VERSION_SEPARATOR + this.newComponentVersion.toString();
             }
-            
+
             const duplicate = this.componentData.find((component) => component.name.toLowerCase() === this.newComponentFinalName.toLowerCase());
 
             if (!isNullOrUndefined(duplicate)) {
@@ -258,7 +258,7 @@ export class WineryAddComponent {
         this.validation.noVersionProvidedWarning = isNullOrUndefined(this.newComponentVersion.componentVersion)
             || this.newComponentVersion.componentVersion.length === 0 || !this.useComponentVersion;
     }
-    
+
     onToggleUseVersion() {
         this.useComponentVersion = !this.useComponentVersion;
         this.onInputChange();

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/RepositoryFactory.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/RepositoryFactory.java
@@ -51,11 +51,11 @@ public class RepositoryFactory {
     }
 
     public static FilebasedRepository createXmlOrYamlRepository(FileBasedRepositoryConfiguration configuration) {
-        if (RepositoryConfigurationObject.RepositoryProvider.FILE.equals(configuration.getRepositoryProvider())) {
+        if (RepositoryConfigurationObject.RepositoryProvider.YAML.equals(configuration.getRepositoryProvider())) {
+            return new YamlRepository(configuration);
+        } else {
             // XML-based repository
             return new FilebasedRepository(configuration);
-        } else {
-            return new YamlRepository(configuration);
         }
     }
 


### PR DESCRIPTION
- Start and end date: 2019-11-26 to 2019-11-26
- Contributor: Felix Burk, @FlxB2 
- Supervisor: Michael Wurster, @miwurster 

Adds a button to enable/disable versioning in the Management UI Dialog when creating a new Service Template/Node Type/Relation Type etc.

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request.
- [x] Branch name checked. That means, the branch name starts with `thesis/`, `fix/`, ...
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [ ] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
