### PR TITLE
Project/radon adds description to properties

### DIFF
--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.html
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.html
@@ -130,10 +130,14 @@
                 <input type="checkbox" id="isRequired" #propertyIsRequired style="margin-right: 7px"/>
                 <label class="control-label" for="isRequired">Is required</label>
             </div>
+            <div class="form-group">
+                <label class="control-label" for="defaultValue">Description</label>
+                <input #propertyDescription id="description" class="form-control" type="text"/>
+            </div>
         </form>
     </winery-modal-body>
     <winery-modal-footer
-        (onOk)="addProperty(selectProperty.value, propName.value, propertyIsRequired.checked, propertyDefaultValue.value); addPropertyFrom.reset();"
+        (onOk)="addProperty(selectProperty.value, propName.value, propertyIsRequired.checked, propertyDefaultValue.value, propertyDescription.value); addPropertyFrom.reset();"
         [closeButtonLabel]="'Cancel'"
         [okButtonLabel]="'Add'"
         [disableOkButton]="!addPropertyFrom?.form.valid">

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinition.component.ts
@@ -50,6 +50,7 @@ export class PropertiesDefinitionComponent implements OnInit {
         { title: 'Type', name: 'type', sort: true },
         { title: 'Is Required', name: 'required' },
         { title: 'Default Value', name: 'defaultValue' },
+        { title: 'Description', name: 'description'}
     ];
     newProperty: PropertiesDefinitionKVElement = new PropertiesDefinitionKVElement();
 
@@ -227,13 +228,17 @@ export class PropertiesDefinitionComponent implements OnInit {
      * Adds a property to the table and model
      * @param propType
      * @param propName
+     * @param required
+     * @param defaultValue
+     * @param description
      */
-    addProperty(propType: string, propName: string, required: boolean, defaultValue: string) {
+    addProperty(propType: string, propName: string, required: boolean, defaultValue: string, description: string) {
         this.resourceApiData.winerysPropertiesDefinition.propertyDefinitionKVList.push({
             key: propName,
             type: propType,
             defaultValue: defaultValue,
             required: required,
+            description: description,
         });
         this.addModal.hide();
     }

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinitionsResourceApiData.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/propertiesDefinition/propertiesDefinitionsResourceApiData.ts
@@ -24,6 +24,7 @@ export class PropertiesDefinitionKVElement {
     type: string = null;
     required: boolean;
     defaultValue: string;
+    description: string;
 }
 
 export class PropertiesDefinition {

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/kvproperties/PropertyDefinitionKV.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/kvproperties/PropertyDefinitionKV.java
@@ -28,6 +28,7 @@ public class PropertyDefinitionKV implements Serializable {
     private String type;
     private Boolean required;
     private String defaultValue;
+    private String description;
 
     public PropertyDefinitionKV() {
         super();
@@ -43,6 +44,11 @@ public class PropertyDefinitionKV implements Serializable {
         this(key, type);
         this.setRequired(required);
         this.setDefaultValue(defaultValue);
+    }
+
+    public PropertyDefinitionKV(String key, String type, Boolean required, String defaultValue, String description) {
+        this(key, type, required, defaultValue);
+        this.setDescription(description);
     }
 
     public String getKey() {
@@ -81,6 +87,14 @@ public class PropertyDefinitionKV implements Serializable {
 
     public void setDefaultValue(String defaultValue) {
         this.defaultValue = defaultValue;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     @Override

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/converter/X2YConverter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/converter/X2YConverter.java
@@ -290,6 +290,7 @@ public class X2YConverter {
                 entry -> new TPropertyDefinition.Builder(convertType(entry.getType()))
                     .setRequired(entry.isRequired())
                     .setDefault(entry.getDefaultValue())
+                    .setDescription(entry.getDescription())
                     .build()
             ));
     }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/converter/Y2XConverter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/converter/Y2XConverter.java
@@ -254,7 +254,8 @@ public class Y2XConverter {
                 new PropertyDefinitionKV(property.getKey(),
                     "xsd:" + tPropDef.getType().getLocalPart(),
                     tPropDef.getRequired(),
-                    tPropDef.getDefault() != null ? tPropDef.getDefault().toString() : null
+                    tPropDef.getDefault() != null ? tPropDef.getDefault().toString() : null,
+                    tPropDef.getDescription()
                 )
             );
         }


### PR DESCRIPTION
- Start and end date: 2019-12-05 to 2019-12-05
- Contributor: Felix Burk, @FlxB2 
- Supervisor: Michael Wurster, @miwurster 

Adds support for description values inside properties definitions

![pr02](https://user-images.githubusercontent.com/7521847/70235299-fdc4fa00-1762-11ea-8560-95a3a6a2515a.png)
![pr01](https://user-images.githubusercontent.com/7521847/70235316-07e6f880-1763-11ea-933c-bb9971c18b11.png)


- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request.
- [x] Branch name checked. That means, the branch name starts with `thesis/`, `fix/`, ...
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Ensure to use auto format in **all** files
- [ ] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [x] Screenshots added (for UI changes)
