### PR TITLE
Fix namespaces file and yaml check in multi-repo setup

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/BackendUtils.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/BackendUtils.java
@@ -1694,6 +1694,7 @@ public class BackendUtils {
         versionList.get(0).setReleasable(true);
 
         boolean changesInFile = false;
+        // Check for MultiRepository
         if (current[0].isVersionedInWinery() && RepositoryFactory.getRepository() instanceof MultiRepository) {
             for (IRepository repository : ((MultiRepository) RepositoryFactory.getRepository()).getRepositories()) {
                 if (repository.getClass().equals(GitBasedRepository.class)) {
@@ -1709,18 +1710,22 @@ public class BackendUtils {
             if (gitRepo.hasChangesInFile(BackendUtils.getRefOfDefinitions(id))) {
                 changesInFile = true;
             }
-            if (!current[0].isLatestVersion()) {
-                // The current version may still be releasable, if it's the latest WIP version of a component version.
-                List<WineryVersion> collect = versionList.stream()
-                    .filter(version -> version.getComponentVersion().equals(current[0].getComponentVersion()))
-                    .sorted(Comparator.reverseOrder())
-                    .collect(Collectors.toList());
-                current[0].setReleasable(collect.get(0).isCurrentVersion());
-                // And if there are changes, it's also editable.
-                current[0].setEditable(changesInFile && current[0].isReleasable());
-            } else {
-                current[0].setEditable(changesInFile);
-            }
+        }
+        // Check if element is unversioned
+        if (!current[0].isVersionedInWinery()) {
+            changesInFile = true;
+        }
+        if (!current[0].isLatestVersion()) {
+            // The current version may still be releasable, if it's the latest WIP version of a component version.
+            List<WineryVersion> collect = versionList.stream()
+                .filter(version -> version.getComponentVersion().equals(current[0].getComponentVersion()))
+                .sorted(Comparator.reverseOrder())
+                .collect(Collectors.toList());
+            current[0].setReleasable(collect.get(0).isCurrentVersion());
+            // And if there are changes, it's also editable.
+            current[0].setEditable(changesInFile && current[0].isReleasable());
+        } else {
+            current[0].setEditable(changesInFile);
         }
 
         return versionList;

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/IRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/IRepository.java
@@ -890,7 +890,7 @@ public interface IRepository extends IWineryRepositoryCommon {
     default void getReferencedRequirementTypeIds(Collection<DefinitionsChildId> ids, TNodeTemplate n) {
         // crawl through reqs/caps
         TNodeTemplate.Requirements requirements = n.getRequirements();
-        if (requirements != null) {
+        if (requirements != null && Environments.getInstance().getRepositoryConfig().getProvider() == RepositoryConfigurationObject.RepositoryProvider.FILE) {
             for (TRequirement req : requirements.getRequirement()) {
                 QName type = req.getType();
                 RequirementTypeId rtId = new RequirementTypeId(type);

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/JsonBasedNamespaceManager.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/JsonBasedNamespaceManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018-2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -162,7 +162,11 @@ public class JsonBasedNamespaceManager extends AbstractNamespaceManager {
 
     @Override
     public void addAllPermanent(Collection<NamespaceProperties> properties) {
-        properties.forEach(prop -> this.namespaceProperties.put(prop.getNamespace(), prop));
+        properties.forEach(prop -> {
+            if (!this.namespaceProperties.containsKey(prop.getNamespace())) {
+                this.namespaceProperties.put(prop.getNamespace(), prop);
+            }
+        });
         this.save();
     }
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/MultiRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/MultiRepository.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019-2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -39,6 +39,7 @@ import org.eclipse.winery.common.RepositoryFileReference;
 import org.eclipse.winery.common.configuration.Environments;
 import org.eclipse.winery.common.configuration.FileBasedRepositoryConfiguration;
 import org.eclipse.winery.common.configuration.GitBasedRepositoryConfiguration;
+import org.eclipse.winery.common.configuration.RepositoryConfigurationObject;
 import org.eclipse.winery.common.ids.GenericId;
 import org.eclipse.winery.common.ids.Namespace;
 import org.eclipse.winery.common.ids.admin.EdmmMappingsId;
@@ -147,8 +148,12 @@ public class MultiRepository implements IRepository {
 
             String pns;
             try {
-                pns = namespace.getEncoded().substring(0, namespace.getEncoded()
-                    .lastIndexOf(RepositoryUtils.getUrlSeparatorEncoded()));
+                if (Environments.getInstance().getRepositoryConfig().getProvider() == RepositoryConfigurationObject.RepositoryProvider.FILE) {
+                    pns = namespace.getEncoded().substring(0, namespace.getEncoded()
+                        .lastIndexOf(RepositoryUtils.getUrlSeparatorEncoded()));
+                } else {
+                    pns = namespace.getEncoded();
+                }
             } catch (UnsupportedEncodingException ex) {
                 LOGGER.error("Error when generating the namespace", ex);
                 return;
@@ -336,11 +341,21 @@ public class MultiRepository implements IRepository {
                     loadConfiguration(configurationFile);
                     loadRepositoriesByList();
                 }
+                fixNamespaces(newSubRepository, url);
             } catch (IOException | GitAPIException e) {
                 LOGGER.error("Error while creating the repository structure");
                 e.printStackTrace();
             }
         }
+    }
+
+    private void fixNamespaces(IRepository repository, String url) {
+        SortedSet<DefinitionsChildId> defChilds = repository.getAllDefinitionsChildIds();
+        Collection<NamespaceProperties> namespaceProperties = new ArrayList<>();
+        for (DefinitionsChildId value : defChilds) {
+            namespaceProperties.add(new NamespaceProperties(value.getNamespace().getDecoded(), value.getNamespace().getDecoded().replace(".", ""), "", url, false));
+        }
+        repository.getNamespaceManager().addAllPermanent(namespaceProperties);
     }
 
     @Override

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/MultiRepositoryManager.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/MultiRepositoryManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019-2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,9 +17,13 @@ package org.eclipse.winery.repository.backend.filebased;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.winery.common.Constants;
 import org.eclipse.winery.common.configuration.Environments;
 import org.eclipse.winery.repository.backend.IRepository;
 import org.eclipse.winery.repository.backend.RepositoryFactory;
@@ -31,7 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class MultiRepositoryManager {
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger(MultiRepositoryManager.class);
 
     /**
@@ -51,6 +55,8 @@ public class MultiRepositoryManager {
             } catch (IOException exception) {
                 exception.printStackTrace();
             }
+            createMultiRepositoryFileStructure(Paths.get(Environments.getInstance().getRepositoryConfig().getRepositoryRoot()),
+                Paths.get(Environments.getInstance().getRepositoryConfig().getRepositoryRoot(), Constants.DEFAULT_LOCAL_REPO_NAME));
         }
         try {
             RepositoryFactory.reconfigure();
@@ -60,10 +66,30 @@ public class MultiRepositoryManager {
     }
 
     /**
+     * Creates the filestructure for a multirepository and moves the files in localRepository to workspace
+     *
+     * @param oldPath The path of the old repository
+     * @param newPath The path of the workspace folder to which the files are moved
+     */
+    private void createMultiRepositoryFileStructure(Path oldPath, Path newPath) {
+        List<String> ignoreFiles = new ArrayList<>();
+        try {
+            Files.createDirectory(newPath);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        ignoreFiles.add(Constants.DEFAULT_LOCAL_REPO_NAME);
+        ignoreFiles.add(Filename.FILENAME_JSON_REPOSITORIES);
+        FileUtils.copyFiles(oldPath, newPath, ignoreFiles);
+        ignoreFiles.add(".git");
+        FileUtils.deleteFiles(oldPath, ignoreFiles);
+    }
+
+    /**
      * If the repository is a MultiRepository, this method will return the list of all repositories in the
-     * MultiRepository. If it is not a MultiRepository, the returned list is empty.
-     * This method will also clone the repositories specified in the repositories.json file and their dependencies.
-     * 
+     * MultiRepository. If it is not a MultiRepository, the returned list is empty. This method will also clone the
+     * repositories specified in the repositories.json file and their dependencies.
+     *
      * @return a list of repositories, represented by their properties.
      */
     public List<RepositoryProperties> getRepositoriesAsList() {


### PR DESCRIPTION
- automatically complete the namespaces file when adding a repository to multirepository
- don't check for Requirement Types in YAML Modes

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request.
- [x] Branch name checked. That means, the branch name starts with `thesis/`, `fix/`, ...
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
