### PR TITLE
Modify css to prevent overflow

### DIFF
--- a/org.eclipse.winery.frontends/app/tosca-management/src/css/wineryRepository.css
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/css/wineryRepository.css
@@ -1189,11 +1189,19 @@ div.col-xs-4.bordered div.listheading > button {
 
 table.dataTable {
     font-size: 12px;
+    max-width: 100%;
+    table-layout: fixed;
 }
 
 table.dataTable thead th {
     font-size: 11px;
     color: #3F3F3F;
+}
+
+table.dataTable tbody tr td {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 div.titledTableBox {


### PR DESCRIPTION
This PR fixes the overflow error for the tables in the management UI.

![image](https://user-images.githubusercontent.com/43381984/74449892-86f05f80-4e7d-11ea-9135-01540577faec.png)

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [x] Screenshots added (for UI changes)
