### PR TITLE
Use short notation for relationship assignments

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/support/writer/YamlPrinter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/support/writer/YamlPrinter.java
@@ -81,6 +81,12 @@ public class YamlPrinter extends AbstractResult<YamlPrinter> {
         return this;
     }
 
+    public YamlPrinter printQName(QName value) {
+        this.stringBuilder.append(qNameToString(value));
+        this.printNewLine();
+        return this;
+    }
+
     public YamlPrinter print(YamlPrinter printer) {
         if (Objects.isNull(printer) || printer.isEmpty()) return this;
         if (endsWithNewLine()) {
@@ -101,7 +107,6 @@ public class YamlPrinter extends AbstractResult<YamlPrinter> {
         if (printer.indent > this.indent && printer.endsWithNewLine()) {
             printer.stringBuilder.setLength(printer.stringBuilder.length() + this.indent - printer.indent);
         }
-
         print(printer.toString());
         return this;
     }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/support/writer/YamlWriter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/support/writer/YamlWriter.java
@@ -507,7 +507,6 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
                 printer.print(parameter.getKey() + ": ").printQName(((TRelationshipAssignment) node).getType())
                     .print(node.accept(this, new Parameter(parameter.getIndent() + INDENT_SIZE)));
             } else if (node instanceof TRelationshipDefinition) {
-                System.out.println("This is the case.");
                 printer.print(parameter.getKey() + ": ").printQName(((TRelationshipDefinition) node).getType())
                     .print(node.accept(this, new Parameter(parameter.getIndent() + INDENT_SIZE)));
             } else {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/support/writer/YamlWriter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/support/writer/YamlWriter.java
@@ -503,7 +503,7 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
                 printer.print(node.accept(this,
                     new Parameter(parameter.getIndent()).addContext(parameter.getKey())
                 ));
-            } else if (node instanceof TRelationshipDefinition || node instanceof TRelationshipAssignment) {
+            } else if (node instanceof TRelationshipAssignment) {
                 printer.print(parameter.getKey() + ": ").printQName(((TRelationshipAssignment) node).getType())
                     .print(node.accept(this, new Parameter(parameter.getIndent() + INDENT_SIZE)));
             } else {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/support/writer/YamlWriter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/support/writer/YamlWriter.java
@@ -324,7 +324,6 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
 
     public YamlPrinter visit(TRelationshipDefinition node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("type", node.getType())
             .print(printMap("interfaces", node.getInterfaces(), parameter));
     }
 
@@ -488,7 +487,6 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
 
     public YamlPrinter visit(TRelationshipAssignment node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
-            .printKeyValue("type", node.getType())
             .print(printMap("properties", node.getProperties(), parameter))
             .print(printMap("interfaces", node.getInterfaces(), parameter));
     }
@@ -505,6 +503,9 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
                 printer.print(node.accept(this,
                     new Parameter(parameter.getIndent()).addContext(parameter.getKey())
                 ));
+            } else if (node instanceof TRelationshipDefinition || node instanceof TRelationshipAssignment) {
+                printer.print(parameter.getKey() + ": ").printQName(((TRelationshipAssignment) node).getType())
+                    .print(node.accept(this, new Parameter(parameter.getIndent() + INDENT_SIZE)));
             } else {
                 printer.printKey(parameter.getKey())
                     .print(node.accept(this, new Parameter(parameter.getIndent() + INDENT_SIZE)));

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/support/writer/YamlWriter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/support/writer/YamlWriter.java
@@ -324,6 +324,7 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
 
     public YamlPrinter visit(TRelationshipDefinition node, Parameter parameter) {
         return new YamlPrinter(parameter.getIndent())
+            .printKeyValue("type", node.getType())
             .print(printMap("interfaces", node.getInterfaces(), parameter));
     }
 
@@ -505,9 +506,6 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
                 ));
             } else if (node instanceof TRelationshipAssignment) {
                 printer.print(parameter.getKey() + ": ").printQName(((TRelationshipAssignment) node).getType())
-                    .print(node.accept(this, new Parameter(parameter.getIndent() + INDENT_SIZE)));
-            } else if (node instanceof TRelationshipDefinition) {
-                printer.print(parameter.getKey() + ": ").printQName(((TRelationshipDefinition) node).getType())
                     .print(node.accept(this, new Parameter(parameter.getIndent() + INDENT_SIZE)));
             } else {
                 printer.printKey(parameter.getKey())

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/support/writer/YamlWriter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/support/writer/YamlWriter.java
@@ -506,6 +506,10 @@ public class YamlWriter extends AbstractVisitor<YamlPrinter, YamlWriter.Paramete
             } else if (node instanceof TRelationshipAssignment) {
                 printer.print(parameter.getKey() + ": ").printQName(((TRelationshipAssignment) node).getType())
                     .print(node.accept(this, new Parameter(parameter.getIndent() + INDENT_SIZE)));
+            } else if (node instanceof TRelationshipDefinition) {
+                System.out.println("This is the case.");
+                printer.print(parameter.getKey() + ": ").printQName(((TRelationshipDefinition) node).getType())
+                    .print(node.accept(this, new Parameter(parameter.getIndent() + INDENT_SIZE)));
             } else {
                 printer.printKey(parameter.getKey())
                     .print(node.accept(this, new Parameter(parameter.getIndent() + INDENT_SIZE)));


### PR DESCRIPTION
This PR makes the service templates yaml files use the short notation for requirement assignments.

E.g:
relationship: con_HostedOn_0

instead of 
relationship:
   type: con_HostedOn_0

- [x ] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request. Especially, we require **a single commit**
- [x ] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x ] Ensure to use auto format in **all** files
- [x ] Ensure that you appear in `NOTICE` at Copyright Holders

