### PR TITLE
Ignore normative types in csar export

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/YamlExporter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/YamlExporter.java
@@ -75,7 +75,6 @@ public class YamlExporter extends CsarExporter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(YamlExporter.class);
     private static final String DEFINITIONS_PATH_PREFIX = "_definitions/";
-    private static final boolean EXPORT_NORMATIVE_TYPES = false;
 
     private final IRepository repository;
 
@@ -119,15 +118,12 @@ public class YamlExporter extends CsarExporter {
             String definitionsPathInsideCSAR = getDefinitionsPathInsideCSAR(repository, currentId);
             CsarContentProperties definitionsFileProperties = new CsarContentProperties(definitionsPathInsideCSAR);
             if (!YamlRepository.ROOT_TYPE_QNAME.equals(currentId.getQName())) {
-                // ignore TOSCA normative types if flag is set to false
-                if (!(currentId.getQName().getNamespaceURI().startsWith("tosca.") && !EXPORT_NORMATIVE_TYPES)) {
-                    referencedIds = exporter.processTOSCA(repository, currentId, definitionsFileProperties, refMap, exportConfiguration);
-                    // for each entryId add license and readme files (if they exist) to the refMap
-                    addLicenseAndReadmeFiles(repository, currentId, refMap);
+                referencedIds = exporter.processTOSCA(repository, currentId, definitionsFileProperties, refMap, exportConfiguration);
+                // for each entryId add license and readme files (if they exist) to the refMap
+                addLicenseAndReadmeFiles(repository, currentId, refMap);
 
-                    exportedState.flagAsExported(currentId);
-                    exportedState.flagAsExportRequired(referencedIds);
-                }
+                exportedState.flagAsExported(currentId);
+                exportedState.flagAsExportRequired(referencedIds);
             }
 
             currentId = exportedState.pop();

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/YamlExporter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/YamlExporter.java
@@ -75,6 +75,7 @@ public class YamlExporter extends CsarExporter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(YamlExporter.class);
     private static final String DEFINITIONS_PATH_PREFIX = "_definitions/";
+    private static final boolean EXPORT_NORMATIVE_TYPES = false;
 
     private final IRepository repository;
 
@@ -118,12 +119,15 @@ public class YamlExporter extends CsarExporter {
             String definitionsPathInsideCSAR = getDefinitionsPathInsideCSAR(repository, currentId);
             CsarContentProperties definitionsFileProperties = new CsarContentProperties(definitionsPathInsideCSAR);
             if (!YamlRepository.ROOT_TYPE_QNAME.equals(currentId.getQName())) {
-                referencedIds = exporter.processTOSCA(repository, currentId, definitionsFileProperties, refMap, exportConfiguration);
-                // for each entryId add license and readme files (if they exist) to the refMap
-                addLicenseAndReadmeFiles(repository, currentId, refMap);
+                // ignore TOSCA normative types if flag is set to false
+                if (!(currentId.getQName().getNamespaceURI().startsWith("tosca.") && !EXPORT_NORMATIVE_TYPES)) {
+                    referencedIds = exporter.processTOSCA(repository, currentId, definitionsFileProperties, refMap, exportConfiguration);
+                    // for each entryId add license and readme files (if they exist) to the refMap
+                    addLicenseAndReadmeFiles(repository, currentId, refMap);
 
-                exportedState.flagAsExported(currentId);
-                exportedState.flagAsExportRequired(referencedIds);
+                    exportedState.flagAsExported(currentId);
+                    exportedState.flagAsExportRequired(referencedIds);
+                }
             }
 
             currentId = exportedState.pop();

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/YamlToscaExportUtil.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/YamlToscaExportUtil.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 
 public class YamlToscaExportUtil extends ToscaExportUtil {
 
+    private static final boolean EXPORT_NORMATIVE_TYPES = false;
     private static final Logger LOGGER = LoggerFactory.getLogger(YamlToscaExportUtil.class);
 
     @Override
@@ -58,16 +59,21 @@ public class YamlToscaExportUtil extends ToscaExportUtil {
 
         Collection<DefinitionsChildId> referencedDefinitionsChildIds = repository.getReferencedDefinitionsChildIds(tcId);
 
-        // adjust imports: add imports of definitions to it
+        if (!EXPORT_NORMATIVE_TYPES) {
+            referencedDefinitionsChildIds.removeIf(id -> id.getQName().getNamespaceURI().startsWith("tosca"));
+        }
+
+        // adjust imports: add imports of definitions
         Collection<TImport> imports = new ArrayList<>();
         for (DefinitionsChildId id : referencedDefinitionsChildIds) {
             this.addToImports(repository, id, imports);
         }
+
         entryDefinitions.getImport().addAll(imports);
 
         // END: Definitions modification
 
-        this.referencesToPathInCSARMap.put(definitionsFileProperties, new YAMLDefinitionsBasedCsarEntry(entryDefinitions));
+        this.referencesToPathInCSARMap.put(definitionsFileProperties, new YAMLDefinitionsBasedCsarEntry(entryDefinitions, EXPORT_NORMATIVE_TYPES));
 
         return referencedDefinitionsChildIds;
     }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/entries/YAMLDefinitionsBasedCsarEntry.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/entries/YAMLDefinitionsBasedCsarEntry.java
@@ -23,6 +23,7 @@ import javax.xml.bind.JAXBException;
 
 import org.eclipse.winery.model.tosca.Definitions;
 import org.eclipse.winery.model.tosca.yaml.TServiceTemplate;
+import org.eclipse.winery.model.tosca.yaml.support.TMapImportDefinition;
 import org.eclipse.winery.repository.JAXBSupport;
 import org.eclipse.winery.repository.backend.IRepository;
 import org.eclipse.winery.repository.backend.RepositoryFactory;
@@ -34,6 +35,15 @@ import org.eclipse.winery.repository.exceptions.WineryRepositoryException;
 
 public class YAMLDefinitionsBasedCsarEntry implements CsarEntry {
     private TServiceTemplate definitions;
+
+    public YAMLDefinitionsBasedCsarEntry(Definitions definitions, boolean exportNormativeTypes) {
+        this(definitions);
+        if (!exportNormativeTypes) {
+            for (TMapImportDefinition map : this.definitions.getImports()) {
+                map.values().removeIf(val -> val.getNamespaceUri().startsWith("tosca"));
+            }
+        }
+    }
 
     public YAMLDefinitionsBasedCsarEntry(Definitions definitions) {
         assert (definitions != null);


### PR DESCRIPTION
Ignore "tosca.**" namesapce during export of csars

- Start and end date: 2020-19-03 to 2020-19-03
- Contributor: Felix Burk, @FlxB2 
- Supervisor: Michael Wurster @miwurster 

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request.
- [x] Branch name checked. That means, the branch name starts with `thesis/`, `fix/`, ...
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
