### PR TITLE
Use correct type name in yaml file

### DIFF
--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/instance.service.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/instance.service.ts
@@ -71,7 +71,7 @@ export class InstanceService {
                 subMenu = [SubMenuItems.readme, SubMenuItems.documentation, SubMenuItems.license, SubMenuItems.appearance, SubMenuItems.instanceStates,
                     SubMenuItems.sourceInterfaces, SubMenuItems.interfaces, SubMenuItems.targetInterfaces, SubMenuItems.validSourcesAndTargets,
                     SubMenuItems.implementations,
-                    SubMenuItems.propertiesDefinition, SubMenuItems.inheritance, SubMenuItems.documentation, SubMenuItems.xml];
+                    SubMenuItems.propertiesDefinition, SubMenuItems.inheritance, SubMenuItems.xml];
                 break;
             case ToscaTypes.ArtifactType:
                 if (this.configurationService.isYaml()) {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/X2YConverter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/X2YConverter.java
@@ -329,9 +329,9 @@ public class X2YConverter {
         TArtifactType.Builder builder = new TArtifactType.Builder()
             .setMimeType(node.getMimeType())
             .setFileExt(node.getFileExtensions());
-
+        String nodeFullName = this.getFullName(node);
         return Collections.singletonMap(
-            node.getIdFromIdOrNameField(),
+            nodeFullName,
             convert(node, builder, org.eclipse.winery.model.tosca.TArtifactType.class).build()
         );
     }
@@ -340,10 +340,7 @@ public class X2YConverter {
         if (Objects.isNull(node)) return null;
         // TNodeTypeImplementation impl = getNodeTypeImplementation(new QName(node.getTargetNamespace(), node.getName()));
 
-        String nodeFullName = node.getIdFromIdOrNameField();
-        if (node.getTargetNamespace() != null) {
-            nodeFullName = node.getTargetNamespace().concat(".").concat(node.getIdFromIdOrNameField());
-        }
+        String nodeFullName = this.getFullName(node);
 
         return Collections.singletonMap(
             nodeFullName,
@@ -382,8 +379,9 @@ public class X2YConverter {
 
     public Map<String, TRelationshipType> convert(org.eclipse.winery.model.tosca.TRelationshipType node) {
         if (Objects.isNull(node)) return null;
+        String nodeFullName = this.getFullName(node);
         return Collections.singletonMap(
-            node.getIdFromIdOrNameField(),
+            nodeFullName,
             convert(node, new TRelationshipType.Builder(), org.eclipse.winery.model.tosca.TRelationshipType.class)
                 .addInterfaces(convert(node.getInterfaces()))
                 .addInterfaces(convert(node.getSourceInterfaces(), "SourceInterfaces"))
@@ -422,8 +420,9 @@ public class X2YConverter {
     @NonNull
     public Map<String, TCapabilityType> convert(org.eclipse.winery.model.tosca.TCapabilityType node) {
         if (Objects.isNull(node)) return new LinkedHashMap<>();
+        String nodeFullName = this.getFullName(node);
         return Collections.singletonMap(
-            node.getName(),
+            nodeFullName,
             convert(node, new TCapabilityType.Builder(), org.eclipse.winery.model.tosca.TCapabilityType.class)
                 .addValidSourceTypes(node.getValidNodeTypes())
                 .build()
@@ -443,8 +442,9 @@ public class X2YConverter {
                 .map(TAppliesTo.NodeTypeReference::getTypeRef)
                 .collect(Collectors.toList()));
         }
+        String nodeFullName = this.getFullName(node);
         return Collections.singletonMap(
-            node.getName(),
+            nodeFullName,
             convert(node, builder, org.eclipse.winery.model.tosca.TPolicyType.class)
                 .build()
         );
@@ -1116,5 +1116,13 @@ public class X2YConverter {
             .map(repository::getElement)
             .filter(entry -> entry.getRelationshipType().equals(relationshipType))
             .findAny().orElse(new TRelationshipTypeImplementation());
+    }
+
+    private String getFullName(org.eclipse.winery.model.tosca.TEntityType node) {
+        String nodeFullName = node.getIdFromIdOrNameField();
+        if (node.getTargetNamespace() != null) {
+            nodeFullName = node.getTargetNamespace().concat(".").concat(node.getIdFromIdOrNameField());
+        }
+        return nodeFullName;
     }
 }


### PR DESCRIPTION
This PR fixes the storage of types in the yaml files.
Use <target-namespace> + <local-name> as name in yaml file.
It also removes a duplicate menu item in the relationship type tab.

Signed-off-by: DominikVoigt <dominik.ingo.voigt@gmail.com>

Use the following template for the PR title and delete this line: [WIP] Title of the thesis/work/target

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request.
- [x] Branch name checked. That means, the branch name starts with `thesis/`, `fix/`, ...
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders