### PR TITLE
Adjustments to YAML CSAR exports

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/YamlExportAdjustmentsBuilder.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/YamlExportAdjustmentsBuilder.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+package org.eclipse.winery.repository.export;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.winery.model.tosca.yaml.TNodeTemplate;
+import org.eclipse.winery.model.tosca.yaml.TServiceTemplate;
+import org.eclipse.winery.model.tosca.yaml.support.TMapImportDefinition;
+import org.eclipse.winery.repository.export.entries.YAMLDefinitionsBasedCsarEntry;
+
+public class YamlExportAdjustmentsBuilder {
+
+    private YAMLDefinitionsBasedCsarEntry entry;
+    private TServiceTemplate definitions;
+
+    public YamlExportAdjustmentsBuilder(YAMLDefinitionsBasedCsarEntry entry) {
+        this.entry = entry;
+        this.definitions = this.entry.getDefinitions();
+    }
+
+    /**
+     * removes imports of normative types
+     */
+    public YamlExportAdjustmentsBuilder removeNormativeTypeImports() {
+        // prevents imports of TOSCA normative types
+        for (TMapImportDefinition map : this.definitions.getImports()) {
+            map.values().removeIf(val -> val.getNamespaceUri().startsWith("tosca"));
+        }
+        return this;
+    }
+
+    /**
+     * changes key values in yaml to the display name
+     */
+    public YamlExportAdjustmentsBuilder setKeysToDisplayName() {
+        if (this.definitions.getTopologyTemplate() != null) {
+            Map<String, TNodeTemplate> newMap = new HashMap<>();
+            Map<String, TNodeTemplate> oldMap = this.definitions.getTopologyTemplate().getNodeTemplates();
+            for (String key : oldMap.keySet()) {
+                newMap.put(oldMap.get(key).getMetadata().get("displayName"), oldMap.get(key));
+            }
+            this.definitions.getTopologyTemplate().setNodeTemplates(newMap);
+        }
+        return this;
+    }
+
+    public YAMLDefinitionsBasedCsarEntry build() {
+        this.entry.setDefinitions(definitions);
+        return entry;
+    }
+}

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/YamlToscaExportUtil.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/YamlToscaExportUtil.java
@@ -72,8 +72,17 @@ public class YamlToscaExportUtil extends ToscaExportUtil {
         entryDefinitions.getImport().addAll(imports);
 
         // END: Definitions modification
+        
+        YAMLDefinitionsBasedCsarEntry entry = new YAMLDefinitionsBasedCsarEntry(entryDefinitions);
 
-        this.referencesToPathInCSARMap.put(definitionsFileProperties, new YAMLDefinitionsBasedCsarEntry(entryDefinitions, EXPORT_NORMATIVE_TYPES));
+        // Custom Adjustments for Service Templates
+        YamlExportAdjustmentsBuilder adjustmentsBuilder = new YamlExportAdjustmentsBuilder(entry);
+        if (!EXPORT_NORMATIVE_TYPES) {
+            adjustmentsBuilder.removeNormativeTypeImports();
+        }
+        entry = adjustmentsBuilder.setKeysToDisplayName().build();
+
+        this.referencesToPathInCSARMap.put(definitionsFileProperties, entry);
 
         return referencedDefinitionsChildIds;
     }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/entries/YAMLDefinitionsBasedCsarEntry.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/entries/YAMLDefinitionsBasedCsarEntry.java
@@ -23,7 +23,6 @@ import javax.xml.bind.JAXBException;
 
 import org.eclipse.winery.model.tosca.Definitions;
 import org.eclipse.winery.model.tosca.yaml.TServiceTemplate;
-import org.eclipse.winery.model.tosca.yaml.support.TMapImportDefinition;
 import org.eclipse.winery.repository.JAXBSupport;
 import org.eclipse.winery.repository.backend.IRepository;
 import org.eclipse.winery.repository.backend.RepositoryFactory;
@@ -35,15 +34,6 @@ import org.eclipse.winery.repository.exceptions.WineryRepositoryException;
 
 public class YAMLDefinitionsBasedCsarEntry implements CsarEntry {
     private TServiceTemplate definitions;
-
-    public YAMLDefinitionsBasedCsarEntry(Definitions definitions, boolean exportNormativeTypes) {
-        this(definitions);
-        if (!exportNormativeTypes) {
-            for (TMapImportDefinition map : this.definitions.getImports()) {
-                map.values().removeIf(val -> val.getNamespaceUri().startsWith("tosca"));
-            }
-        }
-    }
 
     public YAMLDefinitionsBasedCsarEntry(Definitions definitions) {
         assert (definitions != null);
@@ -82,5 +72,13 @@ public class YAMLDefinitionsBasedCsarEntry implements CsarEntry {
         } catch (JAXBException e) {
             throw new IOException(e);
         }
+    }
+
+    public TServiceTemplate getDefinitions() {
+        return definitions;
+    }
+
+    public void setDefinitions(TServiceTemplate definitions) {
+        this.definitions = definitions;
     }
 }


### PR DESCRIPTION
Adds a new builder class which allows to make changes to Service Templates during the export of YAML CSARs. Current adjustments include removing normative types and setting the name of Node Templates to the displayName

- Start and end date: 2020-04-08 to 2020-04-08
- Contributor: Felix Burk @FlxB2 
- Supervisor: Michael Wurster @miwurster 

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request.
- [x] Branch name checked. That means, the branch name starts with `thesis/`, `fix/`, ...
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
