### PR TITLE
Add checks for targetNamespace value

### DIFF
--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/X2YConverter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/converter/X2YConverter.java
@@ -273,6 +273,13 @@ public class X2YConverter {
     public <T extends org.eclipse.winery.model.tosca.yaml.TEntityType.Builder<T>> T convert(TEntityType node, T builder, Class<? extends TEntityType> clazz) {
         TBoolean isFinal = node.getFinal();
         TBoolean isAbstract = node.getAbstract();
+
+        // ensure that the targetNamespace is always set
+        if (Objects.isNull(node.getTargetNamespace()) || node.getTargetNamespace().isEmpty()) {
+            String id = node.getIdFromIdOrNameField();
+            node.setTargetNamespace(id.substring(0, id.lastIndexOf(".")));
+        }
+
         return builder
             .setDerivedFrom(convert(node.getDerivedFrom(), clazz))
             .setMetadata(convert(node.getTags()))
@@ -1122,7 +1129,7 @@ public class X2YConverter {
 
     private String getFullName(org.eclipse.winery.model.tosca.TEntityType node) {
         String nodeFullName = node.getIdFromIdOrNameField();
-        if (node.getTargetNamespace() != null) {
+        if (node.getTargetNamespace() != null && !nodeFullName.contains(node.getTargetNamespace())) {
             nodeFullName = node.getTargetNamespace().concat(".").concat(node.getIdFromIdOrNameField());
         }
         return nodeFullName;


### PR DESCRIPTION
Signed-off-by: Vladimir Yussupov <v.yussupov@gmail.com>

This fix adds a check if the targetNamespace is already contained in the EntityType's id to avoid duplicating it when generating a full name. 
Additionally, this fix ensures that the targetNamespace is set from the type's id in case it was empty, when converting from xml to yaml models. This results in storing this value even if it was not set in the initially loaded definition.

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request.
- [x] Branch name checked. That means, the branch name starts with `thesis/`, `fix/`, ...
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [ ] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
