### PR TITLE
Export types referenced in Requirement- and CapabilityDefinitions

### DIFF
--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/Definitions.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/Definitions.java
@@ -23,11 +23,14 @@ import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "")
 @XmlRootElement(name = "Definitions")
 public class Definitions extends TDefinitions {
     @XmlTransient
+    @JsonIgnore
     protected Map<String, QName> importDefinitions = new HashMap<>();
 
     public Definitions() {

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/Definitions.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/Definitions.java
@@ -13,20 +13,34 @@
 
 package org.eclipse.winery.model.tosca;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import javax.xml.namespace.QName;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "")
 @XmlRootElement(name = "Definitions")
 public class Definitions extends TDefinitions {
+    protected Map<String, QName> importDefinitions = new HashMap<>();
+
     public Definitions() {
     }
 
     public Definitions(Builder builder) {
         super(builder);
+    }
+
+    public Map<String, QName> getImportDefinitions() {
+        return importDefinitions;
+    }
+
+    public void setImportDefinitions(Map<String, QName> importDefinitions) {
+        this.importDefinitions = importDefinitions;
     }
 
     public static class Builder extends TDefinitions.Builder<Builder> {

--- a/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/Definitions.java
+++ b/org.eclipse.winery.model.tosca/src/main/java/org/eclipse/winery/model/tosca/Definitions.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
 
@@ -26,6 +27,7 @@ import javax.xml.namespace.QName;
 @XmlType(name = "")
 @XmlRootElement(name = "Definitions")
 public class Definitions extends TDefinitions {
+    @XmlTransient
     protected Map<String, QName> importDefinitions = new HashMap<>();
 
     public Definitions() {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/IRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/IRepository.java
@@ -605,8 +605,8 @@ public interface IRepository extends IWineryRepositoryCommon {
 
         final TNodeType nodeType = this.getElement(id);
 
-        // add all referenced requirement types, but only in XML mode. YAML does not have requirement types
-
+        // Add all referenced requirement types, but only in XML mode. 
+        // For YAML mode add referenced RelationshipType and CapabilityType, if present
         TNodeType.RequirementDefinitions reqDefsContainer = nodeType.getRequirementDefinitions();
         if (reqDefsContainer != null) {
             List<TRequirementDefinition> reqDefs = reqDefsContainer.getRequirementDefinition();
@@ -617,6 +617,9 @@ public interface IRepository extends IWineryRepositoryCommon {
                 } else {
                     if (Objects.nonNull(reqDef.getRelationship())) {
                         ids.add(new RelationshipTypeId(reqDef.getRelationship()));
+                    }
+                    if (Objects.nonNull(reqDef.getCapability())) {
+                        ids.add(new CapabilityTypeId(reqDef.getCapability()));
                     }
                 }
             }
@@ -629,6 +632,12 @@ public interface IRepository extends IWineryRepositoryCommon {
             for (TCapabilityDefinition capDef : capDefs) {
                 CapabilityTypeId capTypeId = new CapabilityTypeId(capDef.getCapabilityType());
                 ids.add(capTypeId);
+
+                // Add all types referenced in valid source types
+                if (Objects.nonNull(capDef.getValidSourceTypes())) {
+                    capDef.getValidSourceTypes()
+                        .forEach(sourceType -> ids.add(new NodeTypeId(sourceType)));
+                }
             }
         }
 

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/YamlRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/filebased/YamlRepository.java
@@ -630,7 +630,7 @@ public class YamlRepository extends AbstractFileBasedRepository {
     }
 
     /**
-     * Converts incoming xml input stream to yaml service tempalte and writes it to file
+     * Converts incoming xml input stream to yaml service template and writes it to file
      *
      * @param ref         repository file reference
      * @param inputStream input stream to write to file

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/YamlExporter.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/YamlExporter.java
@@ -13,23 +13,12 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.export;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -39,21 +28,11 @@ import org.eclipse.winery.common.Constants;
 import org.eclipse.winery.common.configuration.Environments;
 import org.eclipse.winery.common.constants.MimeTypes;
 import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
-import org.eclipse.winery.model.csar.toscametafile.TOSCAMetaFile;
-import org.eclipse.winery.model.csar.toscametafile.TOSCAMetaFileParser;
-import org.eclipse.winery.model.tosca.Definitions;
-import org.eclipse.winery.model.tosca.yaml.TServiceTemplate;
 import org.eclipse.winery.repository.backend.IRepository;
 import org.eclipse.winery.repository.backend.RepositoryFactory;
 import org.eclipse.winery.repository.backend.filebased.YamlRepository;
-import org.eclipse.winery.repository.converter.Y2XConverter;
-import org.eclipse.winery.repository.converter.support.Utils;
-import org.eclipse.winery.repository.converter.support.exception.MultiException;
-import org.eclipse.winery.repository.converter.support.reader.XmlReader;
-import org.eclipse.winery.repository.converter.support.reader.YamlReader;
 import org.eclipse.winery.repository.datatypes.ids.elements.DirectoryId;
 import org.eclipse.winery.repository.exceptions.RepositoryCorruptException;
-import org.eclipse.winery.repository.exceptions.WineryRepositoryException;
 import org.eclipse.winery.repository.export.entries.CsarEntry;
 import org.eclipse.winery.repository.export.entries.DocumentBasedCsarEntry;
 import org.eclipse.winery.repository.export.entries.RepositoryRefBasedCsarEntry;
@@ -93,6 +72,12 @@ public class YamlExporter extends CsarExporter {
         // the prefix is globally unique and the id locally in a namespace
         // therefore a concatenation of both is also unique
         return repository.getNamespaceManager().getPrefix(id.getNamespace()) + "__" + id.getXmlId().getEncoded();
+    }
+
+    public static String getDefinitionsPathInsideCSAR(IRepository repository, DefinitionsChildId id) {
+        return DEFINITIONS_PATH_PREFIX
+            .concat(getDefinitionsName(repository, id))
+            .concat(Constants.SUFFIX_TOSCA_DEFINITIONS);
     }
 
     /**
@@ -149,12 +134,6 @@ public class YamlExporter extends CsarExporter {
         }
     }
 
-    public static String getDefinitionsPathInsideCSAR(IRepository repository, DefinitionsChildId id) {
-        return DEFINITIONS_PATH_PREFIX
-            .concat(getDefinitionsName(repository, id))
-            .concat(Constants.SUFFIX_TOSCA_DEFINITIONS);
-    }
-
     /**
      * Adds a file to an archive
      *
@@ -171,105 +150,6 @@ public class YamlExporter extends CsarExporter {
         } catch (Exception e) {
             LOGGER.error("Could not copy file content to ZIP outputstream", e);
         }
-    }
-
-    public Definitions convertY2X(TServiceTemplate serviceTemplate, String name, String namespace, Path path, Path outPath) {
-        return new Y2XConverter().convert(serviceTemplate, name, namespace/* TODO, path, outPath*/);
-    }
-
-    public void convertY2X(InputStream zip) throws MultiException {
-        Path path = Utils.unzipFile(zip);
-        LOGGER.debug("Unzip path: {}", path);
-
-        PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:*.{yml,yaml}");
-        MultiException exception = Arrays.stream(Optional.ofNullable(path.toFile().listFiles()).orElse(new File[] {}))
-            .map(File::toPath)
-            .filter(file -> matcher.matches(file.getFileName()))
-            .map(file -> {
-                YamlReader reader = new YamlReader();
-                try {
-                    String id = file.getFileName().toString().substring(0, file.getFileName().toString().lastIndexOf("."));
-                    Path fileName = file.subpath(path.getNameCount(), file.getNameCount());
-                    Path fileOutPath = path.resolve("tmp");
-                    String namespace = reader.getNamespace(path, fileName);
-                    try (InputStream is = new FileInputStream(new File(path.toFile(), fileName.toString()))) {
-                        TServiceTemplate serviceTemplate = reader.parse(is, namespace);
-                        LOGGER.debug("Convert filePath = {}, fileName = {}, id = {}, namespace = {}, fileOutPath = {}",
-                            path, fileName, id, namespace, fileOutPath);
-                        this.convertY2X(serviceTemplate, id, namespace, path, fileOutPath);
-                    } catch (Exception e) {
-                        return new MultiException().add(e);
-                    }
-                } catch (MultiException e) {
-                    return e;
-                }
-                return null;
-            })
-            .filter(Objects::nonNull)
-            .reduce(MultiException::add)
-            .orElse(new MultiException());
-        if (exception.hasException()) throw exception;
-    }
-
-    public InputStream convertX2Y(InputStream csar) {
-        Path filePath = Utils.unzipFile(csar);
-        Path fileOutPath = filePath.resolve("tmp");
-        try {
-            TOSCAMetaFileParser parser = new TOSCAMetaFileParser();
-            TOSCAMetaFile metaFile = parser.parse(filePath.resolve("TOSCA-Metadata").resolve("TOSCA.meta"));
-
-            XmlReader reader = new XmlReader();
-            try {
-                String fileName = metaFile.getEntryDefinitions();
-                Definitions definitions = reader.parse(filePath, Paths.get(fileName));
-                this.convertX2Y(definitions, fileOutPath);
-            } catch (MultiException e) {
-                LOGGER.error("Convert TOSCA XML to TOSCA YAML error", e);
-            }
-            return Utils.zipPath(fileOutPath);
-        } catch (Exception e) {
-            LOGGER.error("Error", e);
-            throw new AssertionError();
-        }
-    }
-
-    public InputStream convertX2Y(DefinitionsChildId id) throws MultiException {
-        Path path = Utils.getTmpDir(Paths.get(id.getQName().getLocalPart()));
-        convertX2Y(repository.getDefinitions(id), path);
-        return Utils.zipPath(path);
-    }
-
-    public String convertDefinitionsChildToYaml(DefinitionsChildId id) throws MultiException {
-        Path path = Utils.getTmpDir(Paths.get(id.getQName().getLocalPart()));
-        convertX2Y(repository.getDefinitions(id), path);
-        // convention: single file in root contains the YAML support
-        // TODO: Links in the YAML should be changed to real links into Winery
-        Optional<Path> rootYamlFile;
-        try {
-            return Files.find(path, 1, (filePath, basicFileAttributes) -> filePath.getFileName().toString().endsWith(".yml"))
-                .findAny()
-                .map(p -> {
-                    try {
-                        return new String(Files.readAllBytes(p), StandardCharsets.UTF_8);
-                    } catch (IOException e) {
-                        LOGGER.debug("Could not read root file", e);
-                        return "Could not read root file";
-                    }
-                })
-                .orElseThrow(() -> {
-                    MultiException multiException = new MultiException();
-                    multiException.add(new WineryRepositoryException("Root YAML file not found."));
-                    return multiException;
-                });
-        } catch (IOException e) {
-            MultiException multiException = new MultiException();
-            multiException.add(new WineryRepositoryException("Root YAML file not found.", e));
-            throw multiException;
-        }
-    }
-
-    public void convertX2Y(Definitions definitions, Path outPath) throws MultiException {
-        // new X2YConverter(this.repository).convert(definitions/*, outPath*/);
     }
 
     private String addManifest(IRepository repository, DefinitionsChildId id, Map<CsarContentProperties, CsarEntry> refMap,

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/YamlToscaExportUtil.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/YamlToscaExportUtil.java
@@ -129,48 +129,30 @@ public class YamlToscaExportUtil extends ToscaExportUtil {
                                         art.setFile("/" + FilenameUtils.separatorsToUnix(pathInsideRepo));
                                     });
                             }
-                        });
 
-                    // update "primary" field in the exported service template
-                    entryDefinitions.getNodeTypes()
-                        .stream()
-                        .filter(nt -> nt.getQName().equals(node.getQName()))
-                        .forEach(nt -> {
                             if (nt.getInterfaceDefinitions() != null) {
                                 nt.getInterfaceDefinitions().forEach(interfaceDefinition -> {
                                     if (interfaceDefinition.getOperations() != null) {
                                         interfaceDefinition.getOperations().forEach(op -> {
                                             if (op.getImplementation() != null) {
+                                                // update "primary" field in the exported service template
                                                 String artifactName = op.getImplementation().getPrimary();
                                                 if (artifactName.equalsIgnoreCase(artifact.getName())) {
                                                     String pathInsideRepo = BackendUtils.getPathInsideRepo(ref);
                                                     op.getImplementation().setPrimary("/" + FilenameUtils.separatorsToUnix(pathInsideRepo));
                                                 }
-                                            }
-                                        });
-                                    }
-                                });
-                            }
-                        });
 
-                    // update "dependencies" field in the exported service template
-                    entryDefinitions.getNodeTypes()
-                        .stream()
-                        .filter(nt -> nt.getQName().equals(node.getQName()))
-                        .forEach(nt -> {
-                            if (nt.getInterfaceDefinitions() != null) {
-                                nt.getInterfaceDefinitions().forEach(interfaceDefinition -> {
-                                    if (interfaceDefinition.getOperations() != null) {
-                                        interfaceDefinition.getOperations().forEach(op -> {
-                                            if (op.getImplementation() != null && op.getImplementation().getDependencies() != null) {
-                                                List<String> dependencies = op.getImplementation().getDependencies().stream().map(artifactName -> {
-                                                    if (artifactName.equalsIgnoreCase(artifact.getName())) {
-                                                        String pathInsideRepo = BackendUtils.getPathInsideRepo(ref);
-                                                        return "/" + FilenameUtils.separatorsToUnix(pathInsideRepo);
-                                                    }
-                                                    return artifactName;
-                                                }).collect(Collectors.toList());
-                                                op.getImplementation().setDependencies(dependencies);
+                                                // update "dependencies" field in the exported service template
+                                                if (op.getImplementation().getDependencies() != null) {
+                                                    List<String> dependencies = op.getImplementation().getDependencies().stream().map(aName -> {
+                                                        if (aName.equalsIgnoreCase(artifact.getName())) {
+                                                            String pathInsideRepo = BackendUtils.getPathInsideRepo(ref);
+                                                            return "/" + FilenameUtils.separatorsToUnix(pathInsideRepo);
+                                                        }
+                                                        return aName;
+                                                    }).collect(Collectors.toList());
+                                                    op.getImplementation().setDependencies(dependencies);
+                                                }
                                             }
                                         });
                                     }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/YamlToscaExportUtil.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/export/YamlToscaExportUtil.java
@@ -19,10 +19,15 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import javax.xml.namespace.QName;
+
+import org.eclipse.winery.common.Constants;
 import org.eclipse.winery.common.RepositoryFileReference;
 import org.eclipse.winery.common.ids.definitions.DefinitionsChildId;
 import org.eclipse.winery.common.ids.definitions.NodeTypeId;
@@ -68,11 +73,16 @@ public class YamlToscaExportUtil extends ToscaExportUtil {
 
         // adjust imports: add imports of definitions
         Collection<TImport> imports = new ArrayList<>();
+        Map<String, QName> importDefinitions = new HashMap<>();
         for (DefinitionsChildId id : referencedDefinitionsChildIds) {
             this.addToImports(repository, id, imports);
+
+            String defName = YamlExporter.getDefinitionsName(repository, id).concat(Constants.SUFFIX_TOSCA_DEFINITIONS);
+            importDefinitions.put(defName, id.getQName());
         }
 
         entryDefinitions.getImport().addAll(imports);
+        entryDefinitions.setImportDefinitions(importDefinitions);
 
         // END: Definitions modification
 


### PR DESCRIPTION
This PR adds export of:
1. CapabilityTypes referenced in RequirementDefinitions
2. NodeTypes referenced as valid source types in CapabilityDefinitions 

Additionally, the unused export code is removed.

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request.
- [x] Branch name checked. That means, the branch name starts with `thesis/`, `fix/`, ...
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [ ] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
