### PR TITLE
Add support for file references as template artifacts

### DIFF
--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/canvas/entities-modal/entities-modal.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/canvas/entities-modal/entities-modal.component.html
@@ -236,23 +236,50 @@
                     </div>
                 </fieldset>
                 <fieldset id="yamlArtifactFileFieldSet">
-                    <div class="form-group" id="yamlArtifactFileDiv"
-                         *ngIf="modalVariantForEditDeleteTasks === '(none)' else artifactFileNameOnly">
-                        <label for="fileUploader">Select Artifact File (will be uploaded when clicking on "Add")</label>
-                        <br>
-                        <input type="file" #fileUploader id="fileUploader" name="fileUploader"
-                               [accept]="selectedYamlArtifactAllowedTypes"
-                               (change)="yamlArtifactFileSelected($event.target.files)"/>
-                    </div>
-                    <ng-template #artifactFileNameOnly>
-                        <div class="form-group" id="yamlArtifactFileNameDiv">
-                            <label for="fileUploader">Selected File</label>
-                            <br>
-                            <button type="button"
-                                    class="btn btn-link btn-anchor"
-                                    (click)="downloadYamlArtifactFile()">{{deploymentArtifactOrPolicyModalData.modalFileName}}</button>
+                    <div class="row">
+                        <div class="col-md-9">
+                            <div class="form-group" id="yamlArtifactFileDiv"
+                                 *ngIf="modalVariantForEditDeleteTasks === '(none)' else artifactFileNameOnly">
+                                <label for="fileUploader">Select Artifact File (will be uploaded when clicking on
+                                    "Add")</label>
+                                <br>
+                                <input type="file" #fileUploader id="fileUploader" name="fileUploader"
+                                       [disabled]="deploymentArtifactOrPolicyModalData.isFileRemote"
+                                       [accept]="selectedYamlArtifactAllowedTypes"
+                                       (change)="yamlArtifactFileSelected($event.target.files)"/>
+                            </div>
+                            <ng-template #artifactFileNameOnly>
+                                <div class="form-group" id="yamlArtifactFileNameDiv">
+                                    <label for="fileUploader">Selected File</label>
+                                    <br>
+                                    <button type="button"
+                                            class="btn btn-link btn-anchor"
+                                            (click)="downloadYamlArtifactFile()">{{deploymentArtifactOrPolicyModalData.modalFileName}}</button>
+                                </div>
+                            </ng-template>
                         </div>
-                    </ng-template>
+                        <div class="col-md-3">
+                            <div class="checkbox">
+                                <label>
+                                    <input id="fileRemote" name="fileRemote"
+                                           [(ngModel)]="deploymentArtifactOrPolicyModalData.isFileRemote"
+                                           (change)="yamlArtifactFileSelected(null)" type="checkbox">
+                                    Specify URL
+                                </label>
+                            </div>
+                        </div>
+
+                    </div>
+                    <div class="row">
+                        <div class="col-md-12">
+                            <div class="form-group" *ngIf="deploymentArtifactOrPolicyModalData.isFileRemote">
+                                <label class="control-label" for="fileRef">Artifact URL</label>
+                                <input class="form-control" id="fileRef" name="fileRef"
+                                       [(ngModel)]="deploymentArtifactOrPolicyModalData.selectedArtifactReference"
+                                       type="text">
+                            </div>
+                        </div>
+                    </div>
                 </fieldset>
                 <fieldset id="yamlDeployPathFieldset">
                     <div class="form-group" id="artifactDeployPathDiv">

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/canvas/entities-modal/entities-modal.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/canvas/entities-modal/entities-modal.component.ts
@@ -161,31 +161,52 @@ export class EntitiesModalComponent implements OnInit, OnChanges, OnDestroy {
 
         if (this.modalVariantAndState.modalVariant === ModalVariant.DeploymentArtifacts && this.configurationService.isYaml()) {
             // the name is retrieved from the open file dialog
-            this.deploymentArtifactOrPolicyModalData.modalFileName = this.selectedYamlArtifactFile.name;
-            const yamlArtifact: TArtifact = new TArtifact(
-                this.deploymentArtifactOrPolicyModalData.modalName,
-                this.deploymentArtifactOrPolicyModalData.modalType,
-                this.deploymentArtifactOrPolicyModalData.modalFileName,
-                this.deploymentArtifactOrPolicyModalData.modalTargetLocation,
-                {},
-                [],
-                [],
-                {}
-            );
-            this.saveYamlArtifactsToModel(yamlArtifact);
-            this.backendService.saveYamlArtifact(
-                this.currentTopologyTemplate,
-                this.currentNodeData.id,
-                yamlArtifact.id,
-                this.selectedYamlArtifactFile,
-            ).subscribe((res) => {
-                this.resetDeploymentArtifactOrPolicyModalData();
-                this.alert.success('Successfully Saved the Artifact!', 'Operation Successful');
-            }, error => {
-                this.alert.info('<p>Something went wrong! The DA was not added to the Topology Template!<br>' + 'Error: '
-                    + error + '</p>');
-            });
-
+            let yamlArtifact: TArtifact;
+            if (this.deploymentArtifactOrPolicyModalData.isFileRemote) {
+                yamlArtifact = new TArtifact(
+                    this.deploymentArtifactOrPolicyModalData.modalName,
+                    this.deploymentArtifactOrPolicyModalData.modalType,
+                    this.deploymentArtifactOrPolicyModalData.selectedArtifactReference,
+                    this.deploymentArtifactOrPolicyModalData.modalTargetLocation,
+                    {},
+                    [],
+                    [],
+                    {}
+                );
+                this.saveYamlArtifactsToModel(yamlArtifact);
+                this.backendService.saveTopologyTemplate(this.currentTopologyTemplate).subscribe((res) => {
+                    this.resetDeploymentArtifactOrPolicyModalData();
+                    this.alert.success('Successfully Saved the Artifact!', 'Operation Successful');
+                }, error => {
+                    this.alert.info('<p>Something went wrong! The DA was not added to the Topology Template!<br>' + 'Error: '
+                        + error + '</p>');
+                });
+            } else {
+                this.deploymentArtifactOrPolicyModalData.modalFileName = this.selectedYamlArtifactFile.name;
+                yamlArtifact = new TArtifact(
+                    this.deploymentArtifactOrPolicyModalData.modalName,
+                    this.deploymentArtifactOrPolicyModalData.modalType,
+                    this.deploymentArtifactOrPolicyModalData.modalFileName,
+                    this.deploymentArtifactOrPolicyModalData.modalTargetLocation,
+                    {},
+                    [],
+                    [],
+                    {}
+                );
+                this.saveYamlArtifactsToModel(yamlArtifact);
+                this.backendService.saveYamlArtifact(
+                    this.currentTopologyTemplate,
+                    this.currentNodeData.id,
+                    yamlArtifact.id,
+                    this.selectedYamlArtifactFile,
+                ).subscribe((res) => {
+                    this.resetDeploymentArtifactOrPolicyModalData();
+                    this.alert.success('Successfully Saved the Artifact!', 'Operation Successful');
+                }, error => {
+                    this.alert.info('<p>Something went wrong! The DA was not added to the Topology Template!<br>' + 'Error: '
+                        + error + '</p>');
+                });
+            }
         } else if (this.modalSelectedRadioButton === 'create' && this.modalVariantAndState.modalVariant === ModalVariant.DeploymentArtifacts) {
             const deploymentArtifactToBeSavedToRedux: TDeploymentArtifact = new TDeploymentArtifact(
                 [],
@@ -490,7 +511,7 @@ export class EntitiesModalComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     yamlArtifactFileSelected(files: FileList) {
-        if (files.length > 0) {
+        if (files && files.length > 0) {
             this.selectedYamlArtifactFile = files[0];
         } else {
             this.selectedYamlArtifactFile = undefined;

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/canvas/entities-modal/modal-model.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/canvas/entities-modal/modal-model.ts
@@ -61,7 +61,11 @@ export class DeploymentArtifactOrPolicyModalData {
         // the file path of a yaml artifact
         public modalFileName?: string,
         // the deployment path of a yaml artifact
-        public modalTargetLocation?: string
+        public modalTargetLocation?: string,
+        // yaml artifact provided as a reference
+        public isFileRemote?: boolean,
+        // file reference
+        public selectedArtifactReference?: string
     ) {
     }
 }


### PR DESCRIPTION
Adds support for using file references as deployment artifacts in node templates in YAML mode.
At export time, the files are downloaded, add into CSAR, and the respective paths are adjusted.

Signed-off-by: Vladimir Yussupov <v.yussupov@gmail.com>

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request.
- [x] Branch name checked. That means, the branch name starts with `thesis/`, `fix/`, ...
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [ ] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
