### PR TITLE
Fixes for addComponent dialog

### DIFF
--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentDataModule/addComponentData.component.html
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentDataModule/addComponentData.component.html
@@ -30,7 +30,7 @@
                     <div [hidden]="!validation?.noDuplicatesAllowed">
                         No duplicates allowed!
                     </div>
-                    <div [hidden]="!newName?.errors?.required">
+                    <div [hidden]="!newName?.errors?.required && !validation?.noNameAvailable">
                         Name is required!
                     </div>
                 </div>

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentDataModule/addComponentData.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentDataModule/addComponentData.component.ts
@@ -74,10 +74,16 @@ export class WineryAddComponentDataComponent {
 
     onInputChange() {
         this.validation = new AddComponentValidation();
+
+        if (!this.newComponentName) {
+            this.validFormEvent.emit(false);
+            return { noNameAvailable: true };
+        }
         this.newComponentFinalName = this.newComponentName;
 
         if (this.typeRequired && !this.newComponentSelectedType) {
             this.validation.noTypeAvailable = true;
+            this.validFormEvent.emit(false);
             return { noTypeAvailable: true };
         }
 
@@ -86,6 +92,7 @@ export class WineryAddComponentDataComponent {
         if (this.newComponentVersion.componentVersion && this.useComponentVersion) {
             this.validation.noUnderscoresAllowed = this.newComponentVersion.componentVersion.includes('_');
             if (this.validation.noUnderscoresAllowed) {
+                this.validFormEvent.emit(false);
                 return { noUnderscoresAllowed: true };
             }
         }
@@ -129,14 +136,17 @@ export class WineryAddComponentDataComponent {
     }
 
     createUrlAndCheck() {
-        this.artifactUrl = backendBaseURL + '/' + this.toscaType + '/' + encodeURIComponent(encodeURIComponent(
-            this.newComponentNamespace)) + '/' + this.newComponentFinalName + '/';
+        const namespace = encodeURIComponent(encodeURIComponent(this.newComponentNamespace));
+        if (this.toscaType && namespace && this.newComponentFinalName) {
+            this.artifactUrl = backendBaseURL + '/' + this.toscaType + '/' + encodeURIComponent(encodeURIComponent(
+                this.newComponentNamespace)) + '/' + this.newComponentFinalName + '/';
 
-        this.existService.check(this.artifactUrl)
-            .subscribe(
-                () => this.validate(false),
-                () => this.validate(true)
-            );
+            this.existService.check(this.artifactUrl)
+                .subscribe(
+                    () => this.validate(false),
+                    () => this.validate(true)
+                );
+        }
         this.newComponentNameEvent.emit(this.newComponentFinalName);
         this.newComponentNamespaceEvent.emit(this.newComponentNamespace);
     }

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentModule/addComponentValidation.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryAddComponentModule/addComponentValidation.ts
@@ -15,6 +15,7 @@ export class AddComponentValidation {
     // Errors
     noDuplicatesAllowed: boolean;
     noUnderscoresAllowed: boolean;
+    noNameAvailable: boolean;
     noTypeAvailable: boolean;
 
     // Warnings

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryNamespaceSelector/wineryNamespaceSelector.component.ts
@@ -17,7 +17,6 @@ import { WineryNotificationService } from '../wineryNotificationModule/wineryNot
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { NamespaceProperties } from '../model/namespaceProperties';
 import { StartNamespaces, ToscaTypes } from '../model/enums';
-import { isNullOrUndefined } from 'util';
 import { HttpErrorResponse } from '@angular/common/http';
 import { WineryRepositoryConfigurationService } from '../wineryFeatureToggleModule/WineryRepositoryConfiguration.service';
 
@@ -75,7 +74,7 @@ const noop = () => {
 export class WineryNamespaceSelectorComponent implements OnInit, ControlValueAccessor {
 
     @Input() isRequired = false;
-    @Input() typeAheadListLimit = 50;
+    @Input() typeAheadListLimit = 10;
     @Input() toscaType: ToscaTypes;
     @Input() useStartNamespace = true;
     @Output() onChange = new EventEmitter<string>();

--- a/org.eclipse.winery.frontends/package-lock.json
+++ b/org.eclipse.winery.frontends/package-lock.json
@@ -6103,9 +6103,9 @@
             "integrity": "sha1-KujTxL7EyoxHbGhcQexKOkQUwtQ="
         },
         "ngx-bootstrap": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-2.0.5.tgz",
-            "integrity": "sha512-IduTVb78RDVlrz2+bn6GXK/REfM/RsRnz/AENwmrgTOg1AtvahJ9qANxXRNn33Kv9GJmkOYy/MhD3DyzeMb16w=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-3.0.0.tgz",
+            "integrity": "sha512-Zu3m5Nwp6ISaqjrFeb1evFoaMn8EDR//RHoKeuLelvFOJjKHaCsbOdkWrAAtpTSapdc892mfZfWdTmSuaN2t5A=="
         },
         "ngx-chips": {
             "version": "1.9.7",

--- a/org.eclipse.winery.frontends/package.json
+++ b/org.eclipse.winery.frontends/package.json
@@ -51,7 +51,7 @@
         "ng2-file-upload": "1.3.0",
         "ng2-select": "2.0.0",
         "ng2-table": "1.3.2",
-        "ngx-bootstrap": "2.0.5",
+        "ngx-bootstrap": "3.0.0",
         "ngx-chips": "1.9.7",
         "ngx-pagination": "3.2.0",
         "ngx-toastr": "9.0.2",


### PR DESCRIPTION
Signed-off-by: Felix Burk <felix.burk@googlemail.com>

The proposed changes fix several issues with addComponent:
- Prevent .../undefined HTTP calls
- Empty names in addComponent dialog are not valid anymore
- Fixes typeahead in addComponent dialog
- Update ngx-bootstrap to prevent issues with rxjs (see below)

The update of ngx-boostrap is necessary because the winery project uses a newer version of rxjs, which is not supported in version 2.0.5 of ngx-boostrap (as mentioned in this [issue](https://github.com/valor-software/ngx-bootstrap/issues/4385)). The changelog of ngx-bootstrap regarding the update from version 2.0.5 to 3.0.0 can be found [here](https://github.com/valor-software/ngx-bootstrap/blob/development/CHANGELOG.md#300-2018-05-17). 
I tested most components of the winery which use ngx-bootstrap, they seem to work fine after the update. Furthermore, the changelog of ngx-bootstrap indicates that nothing should break.

- Start and end date:  2020-10-23 to 2020-10-23
- Contributor: Felix Burk @FlxB2 
- Supervisor: Michael Wurster @miwurster 

---

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request.
- [x] Branch name checked. That means, the branch name starts with `thesis/`, `fix/`, ...
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
