### PR TITLE
Add valid_target_types to RelationshipTypes

### DIFF
--- a/org.eclipse.winery.frontends/app/shared/src/app/model/qName.ts
+++ b/org.eclipse.winery.frontends/app/shared/src/app/model/qName.ts
@@ -33,7 +33,7 @@ export class QName {
         const regex = /\{(.*?)\}(.*)/g;
         const res = regex.exec(this._qName);
 
-        if (res.length !== 3) {
+        if (!res || res.length !== 3) {
             throw new Error();
         }
         this._nameSpace = res[1];

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/instance.service.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/instance.service.ts
@@ -75,7 +75,8 @@ export class InstanceService {
             case ToscaTypes.RelationshipType:
                 if (this.configurationService.isYaml()) {
                     subMenu = [SubMenuItems.readme, SubMenuItems.documentation, SubMenuItems.license, SubMenuItems.appearance,
-                        SubMenuItems.files, SubMenuItems.interfacedefinitions, SubMenuItems.propertiesDefinition, SubMenuItems.inheritance];
+                        SubMenuItems.files, SubMenuItems.interfacedefinitions, SubMenuItems.propertiesDefinition, SubMenuItems.inheritance,
+                        SubMenuItems.validTargetTypes];
                 } else {
                     subMenu = [SubMenuItems.readme, SubMenuItems.documentation, SubMenuItems.license, SubMenuItems.appearance, SubMenuItems.instanceStates,
                         SubMenuItems.sourceInterfaces, SubMenuItems.interfaces, SubMenuItems.targetInterfaces, SubMenuItems.validSourcesAndTargets,
@@ -103,7 +104,7 @@ export class InstanceService {
             case ToscaTypes.CapabilityType:
                 if (this.configurationService.isYaml()) {
                     subMenu = [SubMenuItems.readme, SubMenuItems.license, SubMenuItems.propertiesDefinition, SubMenuItems.inheritance,
-                        SubMenuItems.capabilityTypeConstraints, SubMenuItems.documentation];
+                        SubMenuItems.validSourceTypes, SubMenuItems.documentation];
                 } else {
                     subMenu = [SubMenuItems.readme, SubMenuItems.license, SubMenuItems.propertiesDefinition, SubMenuItems.inheritance,
                         SubMenuItems.documentation, SubMenuItems.xml];

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/validSourceTypes/validSourceTypes.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/validSourceTypes/validSourceTypes.component.ts
@@ -24,6 +24,7 @@ import { BsModalRef, BsModalService, ModalDirective } from 'ngx-bootstrap';
 import { forkJoin } from 'rxjs';
 import { QNameApiData } from '../../../model/qNameApiData';
 import { QName } from '../../../../../../shared/src/app/model/qName';
+import { ToscaTypes } from '../../../model/enums';
 
 @Component({
     selector: 'winery-nodetype-selector',
@@ -38,9 +39,12 @@ import { QName } from '../../../../../../shared/src/app/model/qName';
 export class ValidSourceTypesComponent implements OnInit {
     @Input() title = 'Valid Source Types';
     @Input() resource = 'constraints';
+
+    validType = ToscaTypes.NodeType;
+
     loading: boolean;
-    currentNodeTypes: SelectData[];
-    allNodeTypes: SelectData[];
+    sortedValidTypes: SelectData[];
+    allPossibleValidTypes: SelectData[];
     initialActiveItem: Array<SelectData>;
     currentSelectedItem: QNameApiData;
     validSourceTypes: ValidSourceTypesApiData = new ValidSourceTypesApiData();
@@ -52,20 +56,20 @@ export class ValidSourceTypesComponent implements OnInit {
     ];
 
     constructor(public sharedData: InstanceService,
-                private service: ValidSourceTypesService,
-                private notify: WineryNotificationService,
-                private modalService: BsModalService) {
+                protected service: ValidSourceTypesService,
+                protected notify: WineryNotificationService,
+                protected modalService: BsModalService) {
     }
 
     ngOnInit(): void {
         this.loading = true;
         forkJoin(
-            this.service.getAvailableValidSourceTypes(),
+            this.service.getAvailableGenericType(this.validType),
             this.service.getValidSourceTypes(this.resource)
         ).subscribe(
             ([available, current]) => {
                 this.loading = false;
-                this.handleNodeTypesData(available);
+                this.handleData(available);
                 this.handleValidSourceTypesData(current);
             },
             error => this.handleError(error)
@@ -108,8 +112,8 @@ export class ValidSourceTypesComponent implements OnInit {
     }
 
     handleValidSourceTypesChanged() {
-        if (this.allNodeTypes) {
-            this.currentNodeTypes = this.allNodeTypes
+        if (this.allPossibleValidTypes) {
+            this.sortedValidTypes = this.allPossibleValidTypes
                 .map(parentNode => {
                     if (parentNode.children) {
                         const children = parentNode.children.filter(node => {
@@ -118,27 +122,26 @@ export class ValidSourceTypesComponent implements OnInit {
                                 && qname.namespace === asQName.nameSpace);
                             return existing === null || existing === undefined;
                         });
-
-                        return { id: parentNode.id, text: parentNode.text, children: children };
+                        if (children !== undefined && children.length > 0) {
+                            return { id: parentNode.id, text: parentNode.text, children: children };
+                        }
                     }
-
                     return null;
                 })
                 .filter(item => item !== null);
-
-            if (this.currentNodeTypes !== null
-                && this.currentNodeTypes !== undefined
-                && this.currentNodeTypes.length > 0
-                && this.currentNodeTypes[0].children.length > 0) {
-                this.initialActiveItem = [this.currentNodeTypes[0].children[0]];
+            if (this.sortedValidTypes !== null
+                && this.sortedValidTypes !== undefined
+                && this.sortedValidTypes.length > 0
+                && this.sortedValidTypes[0].children.length > 0) {
+                this.initialActiveItem = [this.sortedValidTypes[0].children[0]];
                 this.onSelectedValueChanged(this.initialActiveItem[0]);
             }
         }
     }
 
-    handleNodeTypesData(nodeTypes: SelectData[]) {
-        this.allNodeTypes = nodeTypes;
-        this.currentNodeTypes = this.allNodeTypes;
+    handleData(nodeTypes: SelectData[]) {
+        this.allPossibleValidTypes = nodeTypes;
+        this.sortedValidTypes = this.allPossibleValidTypes;
     }
 
     handleValidSourceTypesData(data: ValidSourceTypesApiData) {
@@ -149,7 +152,7 @@ export class ValidSourceTypesComponent implements OnInit {
         this.handleValidSourceTypesChanged();
     }
 
-    private handleError(error: HttpErrorResponse): void {
+    protected handleError(error: HttpErrorResponse): void {
         this.loading = false;
         this.notify.error(error.message, 'Error');
     }

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/validSourceTypes/validSourceTypes.service.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/validSourceTypes/validSourceTypes.service.ts
@@ -33,6 +33,11 @@ export class ValidSourceTypesService {
         return this.http.get<ValidSourceTypesApiData>(this.path + '/' + resourceName);
     }
 
+    getAvailableGenericType(type: ToscaTypes): Observable<SelectData[]> {
+        const url = backendBaseURL + '/' + type + '?grouped=angularSelect&dev=true/';
+        return this.http.get<SelectData[]>(url);
+    }
+
     getAvailableValidSourceTypes(): Observable<SelectData[]> {
         const url = backendBaseURL + '/' + ToscaTypes.NodeType + '?grouped=angularSelect&dev=true/';
         return this.http.get<SelectData[]>(url);

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/validTargetTypes/validTargetTypes.component.html
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/validTargetTypes/validTargetTypes.component.html
@@ -1,5 +1,5 @@
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (c) 2019-2020 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2020 Contributors to the Eclipse Foundation
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.
@@ -11,7 +11,7 @@
   ~
   ~ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-<div [class.hidden]="!loading">
+<div *ngIf="loading" style="margin-top: 179px">
     <winery-loader></winery-loader>
 </div>
 <div *ngIf="!loading">
@@ -21,26 +21,23 @@
             Save
         </button>
     </div>
-
     <winery-table [columns]="columns"
                   [data]="validSourceTypes?.nodes"
                   (addBtnClicked)="onAddClick()"
                   (removeBtnClicked)="onRemoveClicked($event)">
     </winery-table>
-
 </div>
-
-
 <ng-template #addModal>
-    <winery-modal-header title="Add {{title}}" [modalRef]="addModalRef">
+    <winery-modal-header title="Add valid target types" [modalRef]="addModalRef">
     </winery-modal-header>
     <winery-modal-body>
         <form>
             <div class="form-group">
-                <label for="validNodeTypes" class="control-label">Node Types</label>
-                <ng-select id="validNodeTypes"
+                <label for="validTargetTypes" class="control-label">Capability Types</label>
+                <ng-select #select
+                           id="validTargetTypes"
                            [disabled]="!sharedData?.currentVersion?.editable"
-                           [items]="allPossibleValidTypes"
+                           [items]="sortedValidTypes"
                            (selected)="onSelectedValueChanged($event)"
                            [active]="initialActiveItem">
                 </ng-select>

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/validTargetTypes/validTargetTypes.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/validTargetTypes/validTargetTypes.component.ts
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+import { Component, Input, ViewChild } from '@angular/core';
+import { BsModalRef, BsModalService, ModalDirective } from 'ngx-bootstrap';
+import { SelectItem } from 'ng2-select';
+import { ValidSourceTypesComponent } from '../validSourceTypes/validSourceTypes.component';
+import { ToscaTypes } from '../../../model/enums';
+import { InstanceService } from '../../instance.service';
+import { ValidSourceTypesService } from '../validSourceTypes/validSourceTypes.service';
+import { WineryNotificationService } from '../../../wineryNotificationModule/wineryNotification.service';
+
+export class ValidTargetType {
+    name: string;
+    namespace: string;
+}
+
+@Component({
+    templateUrl: 'validTargetTypes.component.html',
+    providers: [ValidSourceTypesService]
+})
+export class ValidTargetTypesComponent extends ValidSourceTypesComponent {
+
+    loading = true;
+    resource = 'validtargets';
+
+    validType = ToscaTypes.CapabilityType;
+
+
+    @ViewChild('addModal') addModal: ModalDirective;
+    addModalRef: BsModalRef;
+
+    constructor(public sharedData: InstanceService,
+                protected service: ValidSourceTypesService,
+                protected notify: WineryNotificationService,
+                protected modalService: BsModalService) {
+        super(sharedData, service, notify, modalService);
+    }
+}

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/validTargetTypes/validTargetTypes.module.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/instance/sharedComponents/validTargetTypes/validTargetTypes.module.ts
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *******************************************************************************/
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { BrowserModule } from '@angular/platform-browser';
+import { SelectModule } from 'ng2-select';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { WineryLoaderModule } from '../../../wineryLoader/wineryLoader.module';
+import { WineryQNameSelectorModule } from '../../../wineryQNameSelector/wineryQNameSelector.module';
+import { WineryModalModule } from '../../../wineryModalModule/winery.modal.module';
+import { WineryTableModule } from '../../../wineryTableModule/wineryTable.module';
+import { ValidTargetTypesComponent } from './validTargetTypes.component';
+import { WineryDynamicTableModule } from '../../../wineryDynamicTable/wineryDynamicTable.module';
+
+@NgModule({
+    imports: [
+        CommonModule,
+        BrowserModule,
+        SelectModule,
+        FormsModule,
+        CommonModule,
+        RouterModule,
+        WineryLoaderModule,
+        WineryQNameSelectorModule,
+        WineryModalModule,
+        WineryTableModule,
+        WineryDynamicTableModule
+    ],
+    declarations: [ValidTargetTypesComponent],
+    providers: [],
+})
+export class ValidTargetTypesModule {
+}

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/model/subMenuItem.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/model/subMenuItem.ts
@@ -80,7 +80,8 @@ export class SubMenuItems {
     static readonly threatModeling: SubMenuItem = { displayName: 'Threat Modeling', urlFragment: 'threatmodeling' };
     static readonly topologyTemplate: SubMenuItem = { displayName: 'Topology Template', urlFragment: 'topologytemplate' };
     static readonly validSourcesAndTargets: SubMenuItem = { displayName: 'Valid Sources and Targets', urlFragment: 'validsourcesandtargets' };
-    static readonly capabilityTypeConstraints: SubMenuItem = { displayName: 'Valid Source Types', urlFragment: 'constraints' };
+    static readonly validSourceTypes: SubMenuItem = { displayName: 'Valid Source Types', urlFragment: 'constraints' };
+    static readonly validTargetTypes: SubMenuItem = { displayName: 'Valid Target Types', urlFragment: 'validtargettypes' };
     static readonly supportedFiles: SubMenuItem = { displayName: 'Supported File Types', urlFragment: 'supportedfiles' };
     static readonly xml: SubMenuItem = { displayName: 'XML', urlFragment: 'xml' };
     static readonly attributes: SubMenuItem = { displayName: 'Attribute Definitions', urlFragment: 'attributes' };

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryMainModules/relationshipTypes/relationshipType.module.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryMainModules/relationshipTypes/relationshipType.module.ts
@@ -11,14 +11,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
-import {NgModule} from '@angular/core';
-import {RelationshipTypeRouterModule} from './relationshipTypeRouter.module';
-import {CommonModule} from '@angular/common';
-import {ValidSourcesAndTargetsComponent} from '../../instance/relationshipTypes/validSourcesAndTargets/validSourcesAndTargets.component';
-import {SelectModule} from 'ng2-select';
-import {WineryLoaderModule} from '../../wineryLoader/wineryLoader.module';
-import {WineryReadmeModule} from '../../wineryReadmeModule/wineryReadme.module';
-import {WineryLicenseModule} from '../../wineryLicenseModule/wineryLicense.module';
+import { NgModule } from '@angular/core';
+import { RelationshipTypeRouterModule } from './relationshipTypeRouter.module';
+import { CommonModule } from '@angular/common';
+import { ValidSourcesAndTargetsComponent } from '../../instance/relationshipTypes/validSourcesAndTargets/validSourcesAndTargets.component';
+import { SelectModule } from 'ng2-select';
+import { WineryLoaderModule } from '../../wineryLoader/wineryLoader.module';
+import { WineryReadmeModule } from '../../wineryReadmeModule/wineryReadme.module';
+import { WineryLicenseModule } from '../../wineryLicenseModule/wineryLicense.module';
+import { ValidTargetTypesComponent } from '../../instance/sharedComponents/validTargetTypes/validTargetTypes.component';
+import { ValidTargetTypesModule } from '../../instance/sharedComponents/validTargetTypes/validTargetTypes.module';
 
 @NgModule({
     imports: [
@@ -27,7 +29,8 @@ import {WineryLicenseModule} from '../../wineryLicenseModule/wineryLicense.modul
         WineryLoaderModule,
         RelationshipTypeRouterModule,
         WineryReadmeModule,
-        WineryLicenseModule
+        WineryLicenseModule,
+        ValidTargetTypesModule
     ],
     declarations: [
         ValidSourcesAndTargetsComponent,

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryMainModules/relationshipTypes/relationshipTypeRouter.module.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryMainModules/relationshipTypes/relationshipTypeRouter.module.ts
@@ -31,6 +31,7 @@ import { WineryReadmeComponent } from '../../wineryReadmeModule/wineryReadme.com
 import { WineryLicenseComponent } from '../../wineryLicenseModule/wineryLicense.component';
 import { InterfaceDefinitionsComponent } from '../../instance/sharedComponents/interfaceDefinitions/interfaceDefinitions.component';
 import { FilesComponent } from '../../instance/sharedComponents/filesTag/files.component';
+import { ValidTargetTypesComponent } from '../../instance/sharedComponents/validTargetTypes/validTargetTypes.component';
 
 const toscaType = ToscaTypes.RelationshipType;
 
@@ -54,6 +55,7 @@ const relationshipTypeRoutes: Routes = [
             { path: 'implementations', component: ImplementationsComponent },
             { path: 'propertiesdefinition', component: PropertiesDefinitionComponent },
             { path: 'inheritance', component: InheritanceComponent },
+            { path: 'validtargettypes', component: ValidTargetTypesComponent },
             { path: 'documentation', component: DocumentationComponent },
             { path: 'xml', component: EditXMLComponent },
             { path: 'files', component: FilesComponent },

--- a/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryTableModule/wineryTable.component.ts
+++ b/org.eclipse.winery.frontends/app/tosca-management/src/app/wineryTableModule/wineryTable.component.ts
@@ -11,7 +11,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  *******************************************************************************/
-import { Component, DoCheck, EventEmitter, Input, IterableDiffer, IterableDiffers, OnInit, Output, ViewChild } from '@angular/core';
+import {
+    Component, DoCheck, EventEmitter, Input, IterableDiffer, IterableDiffers, OnInit, Output, ViewChild
+} from '@angular/core';
 
 /**
  * This component provides an easy and fast way to use the ng2-table with further modifications
@@ -187,7 +189,9 @@ export class WineryTableComponent implements OnInit, DoCheck {
         const filteredData = this.changeFilter(this.data, this.config);
         const sortedData = this.changeSort(filteredData, this.config);
         this.rows = (page && config.paging ? this.changePage(page, sortedData) : sortedData)
-            .map((r: any) => { return this.applyDisplay(r); });
+            .map((r: any) => {
+                return this.applyDisplay(r);
+            });
         this.length = sortedData.length;
     }
 
@@ -265,13 +269,7 @@ export class WineryTableComponent implements OnInit, DoCheck {
     }
 
     onCellClick(data: WineryRowData) {
-        // account for pagination to get the actual data
-        const rawIndex = this.rows.indexOf(data.row);
-        const index = this.page ? (this.page - 1) * this.itemsPerPage + rawIndex : rawIndex;
-
-        this.selectedRow = rawIndex;
-        // monkey-patch the data row
-        data.row = this.data[index];
+        this.selectedRow = this.rows.indexOf(data.row);
         this.cellSelected.emit(data);
         this.currentSelected = data.row;
         this.refreshRowHighlighting();

--- a/org.eclipse.winery.model/org.eclipse.winery.model.tosca.canonical/src/main/java/org/eclipse/winery/model/tosca/TRelationshipType.java
+++ b/org.eclipse.winery.model/org.eclipse.winery.model.tosca.canonical/src/main/java/org/eclipse/winery/model/tosca/TRelationshipType.java
@@ -39,7 +39,8 @@ import org.eclipse.jdt.annotation.Nullable;
     "targetInterfaces",
     "interfaceDefinitions",
     "validSource",
-    "validTarget"
+    "validTarget",
+    "validTargetList"
 })
 public class TRelationshipType extends TEntityType {
 
@@ -57,9 +58,14 @@ public class TRelationshipType extends TEntityType {
     protected TRelationshipType.ValidSource validSource;
     @XmlElement(name = "ValidTarget")
     protected TRelationshipType.ValidTarget validTarget;
+    // related to YAML 1.3
+    // https://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.3/os/TOSCA-Simple-Profile-YAML-v1.3-os.html#DEFN_ENTITY_RELATIONSHIP_TYPE
+    @XmlElement(name = "ValidTargetList")
+    protected List<QName> validTargetList;
 
     @Deprecated // used for XML deserialization of API request content
-    public TRelationshipType() { }
+    public TRelationshipType() {
+    }
 
     public TRelationshipType(Builder builder) {
         super(builder);
@@ -70,7 +76,7 @@ public class TRelationshipType extends TEntityType {
         this.interfaceDefinitions = builder.interfaceDefinitions;
         this.validSource = builder.validSource;
         this.validTarget = builder.validTarget;
-        this.interfaceDefinitions = builder.interfaceDefinitions;
+        this.validTargetList = builder.validTargetList;
     }
 
     @Override
@@ -152,6 +158,15 @@ public class TRelationshipType extends TEntityType {
         this.validTarget = value;
     }
 
+    @Nullable
+    public List<QName> getValidTargetList() {
+        return validTargetList;
+    }
+
+    public void setValidTargetList(List<QName> validTargetList) {
+        this.validTargetList = validTargetList;
+    }
+
     @Override
     public void accept(Visitor visitor) {
         visitor.visit(this);
@@ -227,6 +242,7 @@ public class TRelationshipType extends TEntityType {
         private List<TInterfaceDefinition> interfaceDefinitions;
         private ValidSource validSource;
         private ValidTarget validTarget;
+        private List<QName> validTargetList;
 
         public Builder(String name) {
             super(name);
@@ -279,6 +295,32 @@ public class TRelationshipType extends TEntityType {
             TRelationshipType.ValidTarget tmp = new TRelationshipType.ValidTarget();
             tmp.setTypeRef(validTarget);
             return setValidTarget(tmp);
+        }
+
+        public Builder setValidTargetList(List<QName> validTargetList) {
+            this.validTargetList = validTargetList;
+            return this;
+        }
+
+        public Builder addValidTargetsToList(List<QName> validTargetList) {
+            if (validTargetList == null) {
+                return this;
+            }
+            if (this.validTargetList == null) {
+                this.validTargetList = validTargetList;
+            } else {
+                this.validTargetList.addAll(validTargetList);
+            }
+            return this;
+        }
+
+        public Builder addValidTargetToList(QName validTarget) {
+            if (validTarget == null) {
+                return this;
+            }
+
+            this.validTargetList.add(validTarget);
+            return this;
         }
 
         public Builder addInterfaces(TInterfaces interfaces) {

--- a/org.eclipse.winery.model/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/YTRelationshipType.java
+++ b/org.eclipse.winery.model/org.eclipse.winery.model.tosca.yaml/src/main/java/org/eclipse/winery/model/tosca/yaml/YTRelationshipType.java
@@ -130,10 +130,9 @@ public class YTRelationshipType extends YTEntityType {
             }
 
             if (this.validTargetTypes == null) {
-                this.validTargetTypes = new ArrayList<>(validTargetTypes);
-            } else {
-                this.validTargetTypes.addAll(validTargetTypes);
+                this.validTargetTypes = new ArrayList<>();
             }
+            this.validTargetTypes.addAll(validTargetTypes);
 
             return this;
         }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/QNameApiData.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/QNameApiData.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.winery.repository.rest.resources.apiData;
 
+import java.util.Objects;
+
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.namespace.QName;
 
@@ -42,5 +44,19 @@ public class QNameApiData {
         result.namespace = original.getNamespaceURI();
 
         return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        QNameApiData that = (QNameApiData) o;
+        return localname.equals(that.localname) &&
+            namespace.equals(that.namespace);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(localname, namespace);
     }
 }

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/ValidTypesListApiData.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/apiData/ValidTypesListApiData.java
@@ -20,16 +20,19 @@ import java.util.stream.Collectors;
 
 import javax.xml.namespace.QName;
 
-public class ValidSourceTypesApiData {
+/***
+ * used for valid source and target types
+ */
+public class ValidTypesListApiData {
     private List<QNameApiData> nodes;
 
-    public ValidSourceTypesApiData() {
+    public ValidTypesListApiData() {
+
     }
 
-    public ValidSourceTypesApiData(List<QName> qNames) {
+    public ValidTypesListApiData(List<QName> qNames) {
         if (qNames != null) {
-            this.nodes = qNames
-                .stream()
+            this.nodes = qNames.stream()
                 .map(QNameApiData::fromQName)
                 .collect(Collectors.toList());
         } else {
@@ -39,6 +42,10 @@ public class ValidSourceTypesApiData {
 
     public List<QNameApiData> getNodes() {
         return nodes;
+    }
+
+    public List<QName> asQNames() {
+        return nodes.stream().map(QNameApiData::asQName).collect(Collectors.toList());
     }
 
     public void setNodes(List<QNameApiData> nodes) {

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/capabilitytypes/CapabilityTypeResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/capabilitytypes/CapabilityTypeResource.java
@@ -25,7 +25,7 @@ import org.eclipse.winery.model.tosca.TCapabilityType;
 import org.eclipse.winery.model.tosca.TExtensibleElements;
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources.apiData.QNameApiData;
-import org.eclipse.winery.repository.rest.resources.apiData.ValidSourceTypesApiData;
+import org.eclipse.winery.repository.rest.resources.apiData.ValidTypesListApiData;
 import org.eclipse.winery.repository.rest.resources.entitytypes.EntityTypeResource;
 
 import org.slf4j.Logger;
@@ -58,13 +58,13 @@ public final class CapabilityTypeResource extends EntityTypeResource {
 
     @GET
     @Path("constraints/")
-    public ValidSourceTypesApiData getValidSourceTypes() {
-        return new ValidSourceTypesApiData(getCapabilityType().getValidNodeTypes());
+    public ValidTypesListApiData getValidSourceTypes() {
+        return new ValidTypesListApiData(getCapabilityType().getValidNodeTypes());
     }
 
     @PUT
     @Path("constraints/")
-    public Response saveValidSourceTypes(ValidSourceTypesApiData newValidSourceTypes) {
+    public Response saveValidSourceTypes(ValidTypesListApiData newValidSourceTypes) {
         TCapabilityType t = this.getCapabilityType();
         t.setValidNodeTypes(newValidSourceTypes
             .getNodes()

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/policytypes/AppliesToResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/policytypes/AppliesToResource.java
@@ -25,7 +25,7 @@ import org.eclipse.winery.model.tosca.TAppliesTo;
 import org.eclipse.winery.model.tosca.TPolicyType;
 import org.eclipse.winery.repository.rest.RestUtils;
 import org.eclipse.winery.repository.rest.resources.apiData.QNameApiData;
-import org.eclipse.winery.repository.rest.resources.apiData.ValidSourceTypesApiData;
+import org.eclipse.winery.repository.rest.resources.apiData.ValidTypesListApiData;
 
 public class AppliesToResource {
 
@@ -36,7 +36,7 @@ public class AppliesToResource {
     }
     
     @GET
-    public ValidSourceTypesApiData getValidSourceTypes() {
+    public ValidTypesListApiData getValidSourceTypes() {
         List<QName> qNames = null;
 
         if (getPolicyType().getAppliesTo() != null) {
@@ -47,11 +47,11 @@ public class AppliesToResource {
                 .map(TAppliesTo.NodeTypeReference::getTypeRef)
                 .collect(Collectors.toList());
         }
-        return new ValidSourceTypesApiData(qNames);
+        return new ValidTypesListApiData(qNames);
     }
     
     @PUT
-    public Response saveValidSourceTypes(ValidSourceTypesApiData newValidSourceTypes) {
+    public Response saveValidSourceTypes(ValidTypesListApiData newValidSourceTypes) {
         TPolicyType t = this.getPolicyType();
         List<TAppliesTo.NodeTypeReference> references = newValidSourceTypes
             .getNodes()

--- a/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/relationshiptypes/RelationshipTypeResource.java
+++ b/org.eclipse.winery.repository.rest/src/main/java/org/eclipse/winery/repository/rest/resources/entitytypes/relationshiptypes/RelationshipTypeResource.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.winery.repository.rest.resources.entitytypes.relationshiptypes;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.ws.rs.Consumes;
@@ -41,6 +42,7 @@ import org.eclipse.winery.repository.rest.resources._support.GenericFileResource
 import org.eclipse.winery.repository.rest.resources.apiData.QNameApiData;
 import org.eclipse.winery.repository.rest.resources.apiData.ValidEndingsApiData;
 import org.eclipse.winery.repository.rest.resources.apiData.ValidEndingsApiDataSet;
+import org.eclipse.winery.repository.rest.resources.apiData.ValidTypesListApiData;
 import org.eclipse.winery.repository.rest.resources.entitytypes.InstanceStatesResource;
 import org.eclipse.winery.repository.rest.resources.entitytypes.InterfaceDefinitionsResource;
 import org.eclipse.winery.repository.rest.resources.entitytypes.TopologyGraphElementEntityTypeResource;
@@ -113,6 +115,25 @@ public class RelationshipTypeResource extends TopologyGraphElementEntityTypeReso
     @Path("interfacedefinitions")
     public InterfaceDefinitionsResource InterfaceDefinitionsResource() {
         return new InterfaceDefinitionsResource(this);
+    }
+
+    @Path("validtargets")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public ValidTypesListApiData getValidTargets() {
+        if (this.getRelationshipType().getValidTargetList() == null) {
+            return new ValidTypesListApiData(new ArrayList<>());
+        }
+        return new ValidTypesListApiData(this.getRelationshipType().getValidTargetList());
+    }
+
+    @Path("validtargets")
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response saveValidTargets(ValidTypesListApiData validTargets) {
+        this.getRelationshipType().setValidTargetList(validTargets.asQNames());
+
+        return RestUtils.persist(this);
     }
 
     /*

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/IRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/backend/IRepository.java
@@ -883,6 +883,16 @@ public interface IRepository extends IWineryRepositoryCommon {
             }
         }
 
+        List<QName> validTargetList = relationshipType.getValidTargetList();
+        if (validTargetList != null) {
+            for (QName typeRef : validTargetList) {
+                CapabilityTypeId capId = new CapabilityTypeId(typeRef);
+                if (this.exists(capId)) {
+                    ids.add(capId);
+                }
+            }
+        }
+
         TEntityType.PropertiesDefinition properties = relationshipType.getProperties();
         if (Objects.nonNull(properties)) {
             if (properties instanceof TEntityType.XmlElementDefinition

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/yaml/YamlRepository.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/yaml/YamlRepository.java
@@ -659,7 +659,7 @@ public class YamlRepository extends AbstractFileBasedRepository {
             LOGGER.error("Error converting service template. Reason: {}", e.getMessage(), e);
         }
     }
-    
+
     /**
      * Reads xml definition input stream converts it to yaml service template and writes it to input stream
      *
@@ -938,6 +938,7 @@ public class YamlRepository extends AbstractFileBasedRepository {
         oldRelationshipType.setDerivedFrom(newRelationshipType.getDerivedFrom());
         oldRelationshipType.setDescription(newRelationshipType.getDescription());
         oldRelationshipType.setInterfaces(newRelationshipType.getInterfaces());
+        oldRelationshipType.setValidTargetTypes(newRelationshipType.getValidTargetTypes());
         oldData.getRelationshipTypes().entrySet().iterator().next().setValue(oldRelationshipType);
         return oldData;
     }

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/yaml/converter/FromCanonical.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/yaml/converter/FromCanonical.java
@@ -487,19 +487,9 @@ public class FromCanonical {
             nodeFullName,
             convert(node, new YTRelationshipType.Builder(), TRelationshipType.class)
                 .addInterfaces(convert(node.getInterfaceDefinitions()))
-                .addValidTargetTypes(convertTargets(node.getValidSource(), node.getValidTarget()))
+                .setValidTargetTypes(node.getValidTargetList())
                 .build()
         );
-    }
-
-    private List<QName> convertTargets(TRelationshipType.ValidSource validSource, TRelationshipType.ValidTarget validTarget) {
-        if (validSource != null && validTarget != null) {
-            List<QName> output = new ArrayList<>();
-            output.add(new QName(validSource.getTypeRef().getNamespaceURI(), validSource.getTypeRef().getLocalPart()));
-            output.add(new QName(validTarget.getTypeRef().getNamespaceURI(), validSource.getTypeRef().getLocalPart()));
-            return output;
-        }
-        return null;
     }
 
     public Map<String, YTInterfaceDefinition> convert(TInterfaces node, TRelationshipTypeImplementation implementation) {

--- a/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/yaml/converter/ToCanonical.java
+++ b/org.eclipse.winery.repository/src/main/java/org/eclipse/winery/repository/yaml/converter/ToCanonical.java
@@ -781,8 +781,7 @@ public class ToCanonical {
     }
 
     /**
-     * Converts TOSCA YAML RelationshipTypes to TOSCA XML RelationshipTypes Additional element valid_target_types
-     * (specifying Capability Types) is not converted
+     * Converts TOSCA YAML RelationshipTypes to TOSCA XML RelationshipTypes
      *
      * @param node TOSCA YAML RelationshipType
      * @return TOSCA XML RelationshipType
@@ -797,8 +796,10 @@ public class ToCanonical {
             .addSourceInterfaces(convert(node.getInterfaces(), "SourceInterfaces"))
             .addTargetInterfaces(convert(node.getInterfaces(), "TargetInterfaces"))
             .setInterfaceDefinitions(convert(node.getInterfaces()))
-            .setValidSource(convertValidTargetSource(node.getValidTargetTypes(), true))
+            // yaml Relationship Types do not contain valid sources
+            //.setValidSource(convertValidTargetSource(node.getValidTargetTypes(), true))
             .setValidTarget(convertValidTargetSource(node.getValidTargetTypes(), false))
+            .setValidTargetList(node.getValidTargetTypes())
             .build();
         // convertRelationshipTypeImplementation(node.getInterfaces(), id, node.getMetadata().get("targetNamespace"));
         return output;


### PR DESCRIPTION
Signed-off-by: Felix Burk <felix.burk@googlemail.com>

The proposed changes enable users to add `valid_target_types` to Relationship Types

- Start and end date:  2020-11-15 to 2020-11-15
- Contributor: Felix Burk @FlxB2 
- Supervisor: Michael Wurster @miwurster 


Additional changes:
- remove monkey-patch of ng-table in WineryTable component for selecting rows, because it did not work in some edge cases
- several fixes for ValidSourceTypes component which lead to UI breaks

![screen](https://user-images.githubusercontent.com/7521847/99184818-ffa28600-2745-11eb-9efd-c638f04edd36.jpeg)

- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request.
- [x] Branch name checked. That means, the branch name starts with `thesis/`, `fix/`, ...
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [x] Screenshots added (for UI changes)
