### PR TITLE
Adds a sidebar for research plugins and cleans up existing sidebar

### DIFF
--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/canvas/canvas.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/canvas/canvas.component.ts
@@ -12,7 +12,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  ********************************************************************************/
 import {
-    AfterViewInit, Component, ElementRef, HostListener, Input, KeyValueDiffers, NgZone, OnChanges, OnDestroy, OnInit, QueryList, Renderer2, SimpleChanges,
+    AfterViewInit, Component, ElementRef, HostListener, Input, KeyValueDiffers, NgZone, OnChanges, OnDestroy, OnInit,
+    QueryList, Renderer2, SimpleChanges,
     ViewChild, ViewChildren
 } from '@angular/core';
 import { JsPlumbService } from '../services/jsPlumb.service';
@@ -59,6 +60,7 @@ import { WineryRowData } from '../../../../tosca-management/src/app/wineryTableM
 import { InheritanceUtils } from '../models/InheritanceUtils';
 import { PolicyService } from '../services/policy.service';
 import { QName } from '../../../../shared/src/app/model/qName';
+import { DetailsSidebarState } from '../sidebars/node-details/node-details-sidebar';
 
 @Component({
     selector: 'winery-canvas',
@@ -1537,21 +1539,8 @@ export class CanvasComponent implements OnInit, OnDestroy, OnChanges, AfterViewI
      * Hides the Sidebar on the right.
      */
     hideSidebar() {
-        this.ngRedux.dispatch(this.actions.openSidebar({
-            sidebarContents: {
-                visible: false,
-                nodeClicked: false,
-                template: {
-                    id: '',
-                    name: '',
-                    type: '',
-                    properties: '',
-                },
-                relationshipTemplate: undefined,
-                source: '',
-                target: '',
-            }
-        }));
+        this.ngRedux.dispatch(this.actions.triggerSidebar(
+            { sidebarContents: new DetailsSidebarState(false) }));
     }
 
     /**
@@ -1976,7 +1965,7 @@ export class CanvasComponent implements OnInit, OnDestroy, OnChanges, AfterViewI
                 // Workaround to support old topology templates with the real name
                 name = currentRel.type.substring(currentRel.type.indexOf('}') + 1);
             }
-            this.ngRedux.dispatch(this.actions.openSidebar({
+            this.ngRedux.dispatch(this.actions.triggerSidebar({
                 sidebarContents: {
                     visible: true,
                     nodeClicked: false,

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/edmmTransformationCheck/edmmTransformationCheck.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/edmmTransformationCheck/edmmTransformationCheck.component.html
@@ -11,7 +11,7 @@
   ~
   ~ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
-<div id="RefinementView" class="sidebar-root" *ngIf="isVisible">
+<div id="RefinementView">
     <div class="refinementContainer">
         <div class="loader" *ngIf="loading; else showResult"></div>
         <ng-template #showResult>
@@ -29,7 +29,7 @@
                     </div>
                 </li>
             </ul>
-<!--            <button (click)="doTransformationCheck()">Do Check</button>-->
+            <!--            <button (click)="doTransformationCheck()">Do Check</button>-->
         </ng-template>
     </div>
 </div>

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/edmmTransformationCheck/edmmTransformationCheck.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/edmmTransformationCheck/edmmTransformationCheck.component.ts
@@ -29,7 +29,6 @@ import { TTopologyTemplate } from '../models/ttopology-template';
 })
 export class EdmmTransformationCheckComponent {
 
-    isVisible = false;
     loading = false;
     checkResult: EdmmTechnologyTransformationCheck[];
 
@@ -54,7 +53,6 @@ export class EdmmTransformationCheckComponent {
     }
 
     init() {
-        this.isVisible = true;
         this.changeSubscription = this.ngRedux.select(state => state.wineryState.currentJsonTopology)
             .subscribe(element => {
                 if (element.relationshipTemplates && element.relationshipTemplates.length !== this.numberRelations
@@ -67,7 +65,6 @@ export class EdmmTransformationCheckComponent {
     }
 
     hide() {
-        this.isVisible = false;
         if (this.changeSubscription) {
             this.changeSubscription.unsubscribe();
         }

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/enricher/enricher.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/enricher/enricher.component.html
@@ -12,7 +12,7 @@
   ~ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<div id="EnricherView" *ngIf="availableFeatures" class="sidebar-root">
+<div id="EnricherView" *ngIf="availableFeatures">
     <div class="enrichmentContainer">
         <a class="title">Management Feature Enrichment</a>
         <accordion>

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/group-view/group-view.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/group-view/group-view.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="showGroupView" class="sidebar-root">
+<div>
     <div>
         <h5 class="pull-left">Groups</h5>
         <div class="button-bar pull-right">

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/group-view/group-view.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/group-view/group-view.component.ts
@@ -14,7 +14,6 @@ import { WineryDynamicFormModalComponent } from '../../../../tosca-management/sr
 })
 export class GroupViewComponent implements OnInit {
 
-    showGroupView = false;
     groups: TGroupDefinition[] = [];
     formMetadata: Array<WineryDynamicTableMetadata> = [];
 
@@ -24,8 +23,6 @@ export class GroupViewComponent implements OnInit {
 
     constructor(private ngRedux: NgRedux<IWineryState>,
                 private ngActions: WineryActions) {
-        this.ngRedux.select((state) => state.topologyRendererState.buttonsState.manageYamlGroupsButton)
-            .subscribe((showGroupView) => this.showGroupView = showGroupView);
         this.ngRedux.select((state) => state.wineryState.currentJsonTopology)
             .subscribe((topology) => this.groups = topology.groups);
     }

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/navbar/navbar.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/navbar/navbar.component.html
@@ -149,7 +149,7 @@
              data-toggle="buttons">
             <button class="btn btn-sm align-middle dark-button-style"
                     type="button"
-                    id="problemdetection"
+                    id="problemDetection"
                     (click)="toggleButton($event)"
                     [style.background-color]="getStyle(navbarButtonsState.buttonsState.problemDetectionButton)">
                 Detect Problems

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/node.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/node/node.component.ts
@@ -37,6 +37,7 @@ import { WineryRepositoryConfigurationService } from '../../../../tosca-manageme
 import { Subscription } from 'rxjs';
 import { InheritanceUtils } from '../models/InheritanceUtils';
 import { QName } from '../../../../shared/src/app/model/qName';
+import { DetailsSidebarState } from '../sidebars/node-details/node-details-sidebar';
 
 /**
  * Every node has its own component and gets created dynamically.
@@ -472,22 +473,10 @@ export class NodeComponent implements OnInit, AfterViewInit, OnDestroy, DoCheck 
         // close sidebar when longpressing a node template
         if (this.longpress) {
             this.sendPaletteStatus.emit('close Sidebar');
-            this.$ngRedux.dispatch(this.actions.openSidebar({
-                sidebarContents: {
-                    visible: false,
-                    nodeClicked: true,
-                    template: {
-                        id: '',
-                        name: '',
-                        type: '',
-                        properties: {},
-                    },
-                    minInstances: -1,
-                    maxInstances: -1
-                }
-            }));
+            this.$ngRedux.dispatch(this.actions.triggerSidebar(
+                { sidebarContents: new DetailsSidebarState(false, true) }));
         } else {
-            this.$ngRedux.dispatch(this.actions.openSidebar({
+            this.$ngRedux.dispatch(this.actions.triggerSidebar({
                 sidebarContents: {
                     visible: true,
                     nodeClicked: true,

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/participants/manage-participants.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/participants/manage-participants.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="visible" class="sidebar-root">
+<div>
     <div>
         <h5 class="pull-left">Participants</h5>
         <div class="button-bar pull-right">

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/participants/manage-participants.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/participants/manage-participants.component.ts
@@ -14,7 +14,6 @@ import { WineryDynamicFormModalComponent } from '../../../../tosca-management/sr
 })
 export class ManageParticipantsComponent implements OnInit {
 
-    visible = false;
     participants: OTParticipant[] = [];
     formMetadata: Array<WineryDynamicTableMetadata> = [];
 
@@ -22,8 +21,6 @@ export class ManageParticipantsComponent implements OnInit {
 
     constructor(private ngRedux: NgRedux<IWineryState>,
                 private ngActions: WineryActions) {
-        this.ngRedux.select((state) => state.topologyRendererState.buttonsState.manageParticipantsButton)
-            .subscribe((visible) => this.visible = visible);
         this.ngRedux.select((state) => state.wineryState.currentJsonTopology)
             .subscribe((topology) => this.participants = topology.participants);
     }

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/problemDetection/problemDetection.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/problemDetection/problemDetection.component.html
@@ -12,7 +12,7 @@
   ~ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<div id="ProblemDetectionView" *ngIf="!loading && problemFindings" class="sidebar-root">
+<div id="ProblemDetectionView" *ngIf="!loading && problemFindings">
     <div class="detectionContainer" style="margin-top: 1em; margin-left: 1em; margin-right: 1em">
         <a style="font-weight: bold">Detected Problems</a>
         <accordion>

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/redux/actions/topologyRenderer.actions.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/redux/actions/topologyRenderer.actions.ts
@@ -59,8 +59,13 @@ export class TopologyRendererActions {
     static SHOW_MANAGE_YAML_GROUPS = 'SHOW_MANAGE_YAML_GROUPS';
     static TOGGLE_MANAGE_YAML_GROUPS = 'TOGGLE_MANAGE_YAML_GROUPS';
     static TOGGLE_YAML_GROUPS = 'TOGGLE_YAML_GROUPS';
+    static DISABLE_RESEARCH_PLUGIN = 'DISABLE_RESEARCH_PLUGIN';
     static TOGGLE_MANAGE_PARTICIPANTS = 'TOGGLE_MANAGE_PARTICIPANTS';
     static TOGGLE_ASSIGN_PARTICIPANTS = 'TOGGLE_ASSIGN_PARTICIPANTS';
+
+    disableResearchPlugin(): Action {
+        return { type: TopologyRendererActions.DISABLE_RESEARCH_PLUGIN };
+    }
 
     togglePolicies(): Action {
         return { type: TopologyRendererActions.TOGGLE_POLICIES };

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/redux/actions/winery.actions.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/redux/actions/winery.actions.ts
@@ -235,7 +235,7 @@ export class WineryActions {
     static DELETE_NODE_TEMPLATE = 'DELETE_NODE_TEMPLATE';
     static DELETE_RELATIONSHIP_TEMPLATE = 'DELETE_RELATIONSHIP_TEMPLATE';
     static CHANGE_NODE_NAME = 'CHANGE_NODE_NAME';
-    static OPEN_SIDEBAR = 'OPEN_SIDEBAR';
+    static TRIGGER_SIDEBAR = 'TRIGGER_SIDEBAR';
     static UPDATE_NODE_COORDINATES = 'UPDATE_NODE_COORDINATES';
     static UPDATE_REL_DATA = 'UPDATE_REL_DATA';
     static CHANGE_MIN_INSTANCES = 'CHANGE_MIN_INSTANCES';
@@ -278,9 +278,9 @@ export class WineryActions {
             type: WineryActions.HIDE_NAVBAR_AND_PALETTE,
             hideNavBarAndPalette: hideNavBarAndPalette
         }));
-    openSidebar: ActionCreator<SidebarStateAction> =
+    triggerSidebar: ActionCreator<SidebarStateAction> =
         ((newSidebarData) => ({
-            type: WineryActions.OPEN_SIDEBAR,
+            type: WineryActions.TRIGGER_SIDEBAR,
             sidebarContents: newSidebarData.sidebarContents
         }));
     changeNodeName: ActionCreator<SidebarChangeNodeName> =

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/redux/reducers/topologyRenderer.reducer.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/redux/reducers/topologyRenderer.reducer.ts
@@ -15,6 +15,15 @@
 import { Action } from 'redux';
 import { HighlightNodesAction, TopologyRendererActions } from '../actions/topologyRenderer.actions';
 
+export type PossibleResearchPlugins =
+    'REFINEMENT'
+    | 'PROBLEM_DETECTION'
+    | 'ENRICHER'
+    | 'EDDM_TRANSFORM'
+    | 'GROUP_VIEW'
+    | 'MNG_PARTICIPANTS'
+    | 'MULTI_PARTICIPANTS';
+
 export interface TopologyRendererState {
     buttonsState: {
         targetLocationsButton?: boolean;
@@ -52,7 +61,9 @@ export interface TopologyRendererState {
         manageParticipantsButton?: boolean;
         assignParticipantsButton?: boolean;
     };
+    activeResearchPlugin: PossibleResearchPlugins;
     nodesToSelect?: string[];
+
 }
 
 export const INITIAL_TOPOLOGY_RENDERER_STATE: TopologyRendererState = {
@@ -91,6 +102,7 @@ export const INITIAL_TOPOLOGY_RENDERER_STATE: TopologyRendererState = {
         yamlGroupsButton: false,
         manageParticipantsButton: false,
     },
+    activeResearchPlugin: undefined,
 };
 /**
  * Reducer for the TopologyRenderer
@@ -98,13 +110,28 @@ export const INITIAL_TOPOLOGY_RENDERER_STATE: TopologyRendererState = {
 export const TopologyRendererReducer =
     function (lastState: TopologyRendererState = INITIAL_TOPOLOGY_RENDERER_STATE, action: Action): TopologyRendererState {
         switch (action.type) {
+            // disables all research plugins globally
+            case TopologyRendererActions.DISABLE_RESEARCH_PLUGIN:
+                return {
+                    ...lastState,
+                    buttonsState: {
+                        ...lastState.buttonsState,
+                        manageYamlGroupsButton: false,
+                        manageParticipantsButton: false,
+                        problemDetectionButton: false,
+                        enrichmentButton: false,
+                        edmmTransformationCheck: false,
+
+                    },
+                    activeResearchPlugin: undefined
+                };
             case TopologyRendererActions.TOGGLE_YAML_GROUPS:
                 return {
                     ...lastState,
                     buttonsState: {
                         ...lastState.buttonsState,
-                        yamlGroupsButton: !lastState.buttonsState.yamlGroupsButton
-                    }
+                        yamlGroupsButton: !lastState.buttonsState.yamlGroupsButton,
+                    },
                 };
             case TopologyRendererActions.SHOW_MANAGE_YAML_GROUPS:
                 return {
@@ -112,7 +139,8 @@ export const TopologyRendererReducer =
                     buttonsState: {
                         ...lastState.buttonsState,
                         manageYamlGroupsButton: true
-                    }
+                    },
+                    activeResearchPlugin: 'GROUP_VIEW'
                 };
             case TopologyRendererActions.TOGGLE_MANAGE_YAML_GROUPS:
                 return {
@@ -120,7 +148,8 @@ export const TopologyRendererReducer =
                     buttonsState: {
                         ...lastState.buttonsState,
                         manageYamlGroupsButton: !lastState.buttonsState.manageYamlGroupsButton
-                    }
+                    },
+                    activeResearchPlugin: !lastState.buttonsState.manageYamlGroupsButton ? 'GROUP_VIEW' : undefined,
                 };
             case TopologyRendererActions.TOGGLE_MANAGE_PARTICIPANTS:
                 return {
@@ -128,7 +157,8 @@ export const TopologyRendererReducer =
                     buttonsState: {
                         ...lastState.buttonsState,
                         manageParticipantsButton: !lastState.buttonsState.manageParticipantsButton
-                    }
+                    },
+                    activeResearchPlugin: !lastState.buttonsState.manageParticipantsButton ? 'MNG_PARTICIPANTS' : undefined,
                 };
             case TopologyRendererActions.TOGGLE_ASSIGN_PARTICIPANTS:
                 return {
@@ -208,7 +238,8 @@ export const TopologyRendererReducer =
                     buttonsState: {
                         ...lastState.buttonsState,
                         edmmTransformationCheck: !lastState.buttonsState.edmmTransformationCheck
-                    }
+                    },
+                    activeResearchPlugin: !lastState.buttonsState.edmmTransformationCheck ? 'EDDM_TRANSFORM' : undefined,
                 };
             case TopologyRendererActions.EXECUTE_LAYOUT:
                 return {
@@ -272,7 +303,8 @@ export const TopologyRendererReducer =
                     buttonsState: {
                         ...lastState.buttonsState,
                         problemDetectionButton: !lastState.buttonsState.problemDetectionButton
-                    }
+                    },
+                    activeResearchPlugin: !lastState.buttonsState.problemDetectionButton ? 'PROBLEM_DETECTION' : undefined,
                 };
             case TopologyRendererActions.ENRICH_NODE_TEMPLATES:
                 return {
@@ -280,7 +312,8 @@ export const TopologyRendererReducer =
                     buttonsState: {
                         ...lastState.buttonsState,
                         enrichmentButton: !lastState.buttonsState.enrichmentButton
-                    }
+                    },
+                    activeResearchPlugin: !lastState.buttonsState.enrichmentButton ? 'ENRICHER' : undefined,
                 };
             case TopologyRendererActions.SUBSTITUTE_TOPOLOGY:
                 return {

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/redux/reducers/winery.reducer.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/redux/reducers/winery.reducer.ts
@@ -90,7 +90,7 @@ export const WineryReducer =
                     ...lastState,
                     hideNavBarAndPaletteState: hideNavBarAndPalette
                 };
-            case WineryActions.OPEN_SIDEBAR:
+            case WineryActions.TRIGGER_SIDEBAR:
                 const newSidebarData: DetailsSidebarState = (<SidebarStateAction>action).sidebarContents;
 
                 return <WineryState>{

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/sidebars/node-details/node-details-sidebar.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/sidebars/node-details/node-details-sidebar.ts
@@ -14,16 +14,34 @@
 import { TRelationshipTemplate } from '../../models/ttopology-template';
 
 export class DetailsSidebarState {
-    visible: boolean;
-    nodeClicked: boolean;
-    template: SidebarEntityTemplate;
-    relationshipTemplate?: TRelationshipTemplate;
-    minInstances: number;
-    // this shoehorns the possibility of unicode infinity into the type
-    maxInstances: number | '\u221E';
-    // relationship editing information
-    source: any;
-    target: any;
+    constructor(
+        public visible: boolean,
+        public nodeClicked?: boolean,
+        public template?: SidebarEntityTemplate,
+        public relationshipTemplate?: TRelationshipTemplate,
+        public minInstances?: number,
+        // this shoehorns the possibility of unicode infinity into the type
+        public maxInstances?: number | '\u221E',
+        // relationship editing information
+        public source?: any,
+        public target?: any) {
+
+        if (!template) {
+            this.template = {
+                id: '',
+                name: '',
+                type: '',
+                properties: {}
+            };
+        }
+
+        if (!minInstances) {
+            this.minInstances = -1;
+        }
+        if (!maxInstances) {
+            this.maxInstances = -1;
+        }
+    }
 }
 
 export class SidebarEntityTemplate {

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/sidebars/node-details/nodeDetailsSidebar.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/sidebars/node-details/nodeDetailsSidebar.component.ts
@@ -23,7 +23,6 @@ import { urlElement } from '../../models/enums';
 import { BackendService } from '../../services/backend.service';
 import { PolicyService } from '../../services/policy.service';
 import { DetailsSidebarState } from './node-details-sidebar';
-import { WineryRepositoryConfigurationService } from '../../../../../tosca-management/src/app/wineryFeatureToggleModule/WineryRepositoryConfiguration.service';
 import { QName } from '../../../../../shared/src/app/model/qName';
 
 /**
@@ -32,7 +31,7 @@ import { QName } from '../../../../../shared/src/app/model/qName';
 @Component({
     selector: 'winery-node-details-sidebar',
     templateUrl: './nodeDetailsSidebar.component.html',
-    styleUrls: ['./nodeDetailsSidebar.component.css'],
+    styleUrls: ['../sidebar.css'],
 })
 export class NodeDetailsSidebarComponent implements OnInit, OnDestroy {
     // ngRedux sidebarSubscription
@@ -51,8 +50,7 @@ export class NodeDetailsSidebarComponent implements OnInit, OnDestroy {
     constructor(private $ngRedux: NgRedux<IWineryState>,
                 private actions: WineryActions,
                 private backendService: BackendService,
-                private policyService: PolicyService,
-                private repoConfiguration: WineryRepositoryConfigurationService) {
+                private policyService: PolicyService) {
     }
 
     deleteButtonSidebarClicked($event) {
@@ -66,21 +64,8 @@ export class NodeDetailsSidebarComponent implements OnInit, OnDestroy {
      * Closes the sidebar.
      */
     closeSidebar() {
-        this.$ngRedux.dispatch(this.actions.openSidebar({
-            sidebarContents: {
-                visible: false,
-                nodeClicked: false,
-                template: {
-                    id: '',
-                    name: '',
-                    type: '',
-                    properties: {}
-                },
-                relationshipTemplate: undefined,
-                minInstances: -1,
-                maxInstances: -1,
-            }
-        }));
+        this.$ngRedux.dispatch(this.actions.triggerSidebar(
+            { sidebarContents: new DetailsSidebarState(false) }));
     }
 
     /**
@@ -96,14 +81,14 @@ export class NodeDetailsSidebarComponent implements OnInit, OnDestroy {
      */
     ngOnInit() {
         this.sidebarSubscription = this.$ngRedux.select<DetailsSidebarState>(
-                wineryState => wineryState.wineryState.sidebarContents
-            ).subscribe(sidebarContents => {
-                    this.sidebarState = sidebarContents;
-                    if (!this.sidebarState.template.name) {
-                        this.sidebarState.template.name = this.sidebarState.template.id;
-                    }
+            wineryState => wineryState.wineryState.sidebarContents
+        ).subscribe(sidebarContents => {
+                this.sidebarState = sidebarContents;
+                if (!this.sidebarState.template.name) {
+                    this.sidebarState.template.name = this.sidebarState.template.id;
                 }
-            );
+            }
+        );
         // apply changes to the node name <input> field with a debounceTime of 300ms
         this.subscription = this.nodeNameKeyUp.pipe(
             debounceTime(300),
@@ -128,7 +113,7 @@ export class NodeDetailsSidebarComponent implements OnInit, OnDestroy {
                     }));
                 }
                 // refresh
-                this.$ngRedux.dispatch(this.actions.openSidebar({
+                this.$ngRedux.dispatch(this.actions.triggerSidebar({
                     sidebarContents: {
                         visible: true,
                         nodeClicked: this.sidebarState.nodeClicked,
@@ -161,7 +146,7 @@ export class NodeDetailsSidebarComponent implements OnInit, OnDestroy {
                     }));
                 }
                 // refresh
-                this.$ngRedux.dispatch(this.actions.openSidebar({
+                this.$ngRedux.dispatch(this.actions.triggerSidebar({
                     sidebarContents: {
                         visible: true,
                         nodeClicked: this.sidebarState.nodeClicked,
@@ -188,7 +173,7 @@ export class NodeDetailsSidebarComponent implements OnInit, OnDestroy {
                     }));
                 }
                 // refresh
-                this.$ngRedux.dispatch(this.actions.openSidebar({
+                this.$ngRedux.dispatch(this.actions.triggerSidebar({
                     sidebarContents: {
                         visible: true,
                         nodeClicked: this.sidebarState.nodeClicked,
@@ -230,7 +215,7 @@ export class NodeDetailsSidebarComponent implements OnInit, OnDestroy {
             }
         }
         // refresh
-        this.$ngRedux.dispatch(this.actions.openSidebar({
+        this.$ngRedux.dispatch(this.actions.triggerSidebar({
             sidebarContents: {
                 visible: true,
                 nodeClicked: this.sidebarState.nodeClicked,
@@ -290,7 +275,7 @@ export class NodeDetailsSidebarComponent implements OnInit, OnDestroy {
             this.maxInputEnabled = true;
         }
         // refresh
-        this.$ngRedux.dispatch(this.actions.openSidebar({
+        this.$ngRedux.dispatch(this.actions.triggerSidebar({
             sidebarContents: {
                 visible: true,
                 nodeClicked: this.sidebarState.nodeClicked,

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/sidebars/refinement/refinementSidebar.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/sidebars/refinement/refinementSidebar.component.html
@@ -12,7 +12,7 @@
   ~ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<div id="RefinementView" class="sidebar-root">
+<div id="RefinementView">
     <div class="refinementContainer">
         <div class="informationContainer" *ngIf="!refinementIsRunning; else showIsRunning">
             <div *ngIf="refinementIsDone; else showStart">
@@ -26,7 +26,8 @@
             <div class="loader" *ngIf="refinementIsLoading; else showContent"></div>
             <ng-template #showContent>
                 <ul>
-                    <li *ngFor="let candidate of prmCandidates" (mouseover)="onHoverOver(candidate)" (mouseleave)="hoverOut()">
+                    <li *ngFor="let candidate of prmCandidates" (mouseover)="onHoverOver(candidate)"
+                        (mouseleave)="hoverOut()">
                         {{ candidate.refinementModel.name }}
                         <br>
                         <div class="btn-group">
@@ -35,7 +36,8 @@
                                 Show Refinement Structure
                             </button>
                             <br>
-                            <button class="btn btn-sm btn-primary" (click)="prmChosen($event, candidate)">Choose</button>
+                            <button class="btn btn-sm btn-primary" (click)="prmChosen($event, candidate)">Choose
+                            </button>
                         </div>
                     </li>
                 </ul>

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/sidebars/research-plugins/research-plugins.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/sidebars/research-plugins/research-plugins.component.html
@@ -1,0 +1,28 @@
+<div id="NTPropertiesView"
+     class="sidebar-root"
+     style="display: block;">
+    <div id="nodeTemplateInformationSection" style="padding: 1em">
+        <div [ngSwitch]="selectedPlugin">
+            <div *ngSwitchCase="'REFINEMENT'">
+                <winery-refinement *ngIf="refiningType; else elseBlock"
+                                   [refinementType]="refiningType"></winery-refinement>
+                <ng-template #elseBlock> Error Refining Type not set</ng-template>
+            </div>
+            <winery-problem-detection
+                *ngSwitchCase="'PROBLEM_DETECTION'"></winery-problem-detection>
+            <winery-enricher *ngSwitchCase="'ENRICHER'"></winery-enricher>
+            <winery-edmm-transformation-check
+                *ngSwitchCase="'EDDM_TRANSFORM'"></winery-edmm-transformation-check>
+            <winery-group-view *ngSwitchCase="'GROUP_VIEW'"></winery-group-view>
+            <winery-manage-participants
+                *ngSwitchCase="'MNG_PARTICIPANTS'"></winery-manage-participants>
+            <winery-multi-participants
+                *ngSwitchCase="'MULTI_PARTICIPANTS'"></winery-multi-participants>
+        </div>
+        <button
+            class="btn btn-secondary btn-sm btn-block align-middle" type="button"
+            style="margin-top: 1em"
+            (click)="closeSidebar()">Close
+        </button>
+    </div>
+</div>

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/sidebars/research-plugins/research-plugins.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/sidebars/research-plugins/research-plugins.component.ts
@@ -1,0 +1,42 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { PossibleResearchPlugins, TopologyRendererState } from '../../redux/reducers/topologyRenderer.reducer';
+import { NgRedux } from '@angular-redux/store';
+import { IWineryState } from '../../redux/store/winery.store';
+import { TopologyRendererActions } from '../../redux/actions/topologyRenderer.actions';
+import { Subscription } from 'rxjs';
+
+@Component({
+    selector: 'winery-research-plugins',
+    templateUrl: './research-plugins.component.html',
+    styleUrls: ['../sidebar.css'],
+})
+export class ResearchPluginsComponent {
+
+    @Input()
+    selectedPlugin: PossibleResearchPlugins;
+
+    refiningType: string;
+    subscriptions: Array<Subscription> = [];
+
+    constructor(private ngRedux: NgRedux<IWineryState>,
+                private actions: TopologyRendererActions) {
+        this.subscriptions.push(this.ngRedux.select(state => state.topologyRendererState)
+            .subscribe(currentButtonsState => this.setButtonsState(currentButtonsState)));
+    }
+
+    closeSidebar() {
+        this.ngRedux.dispatch(this.actions.disableResearchPlugin());
+    }
+
+    private setButtonsState(currentButtonsState: TopologyRendererState) {
+        if (currentButtonsState.buttonsState.refineTopologyButton) {
+            this.refiningType = 'topology';
+        } else if (currentButtonsState.buttonsState.refinePatternsButton) {
+            this.refiningType = 'patterns';
+        } else if (currentButtonsState.buttonsState.refineTopologyWithTestsButton) {
+            this.refiningType = 'tests';
+        } else {
+            delete this.refiningType;
+        }
+    }
+}

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/sidebars/sidebar.css
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/sidebars/sidebar.css
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017-2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/winery.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/winery.component.html
@@ -24,6 +24,14 @@
                                      class="sidebar">
         </winery-node-details-sidebar>
     </ng-sidebar>
+    <ng-sidebar class="winery-sidebar"
+                *ngIf="activeResearchPlugin != undefined"
+                [opened]="activeResearchPlugin != undefined"
+                [position]="'right'">
+        <winery-research-plugins class="sidebar"
+                                 [selectedPlugin]="activeResearchPlugin">
+        </winery-research-plugins>
+    </ng-sidebar>
 
     <div ng-sidebar-content>
 
@@ -47,16 +55,6 @@
                                           [entityTypes]="this.entityTypes">
                 </winery-palette-component>
             </div>
-        </div>
-
-        <div class="sidebar-container">
-            <winery-refinement *ngIf="refiningType" [refinementType]="refiningType"></winery-refinement>
-            <winery-problem-detection></winery-problem-detection>
-            <winery-enricher></winery-enricher>
-            <winery-edmm-transformation-check></winery-edmm-transformation-check>
-            <winery-group-view></winery-group-view>
-            <winery-manage-participants></winery-manage-participants>
-            <winery-multi-participants></winery-multi-participants>
         </div>
 
         <winery-version-slider *ngIf="showVersionSlider"></winery-version-slider>

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/winery.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/winery.component.ts
@@ -26,11 +26,12 @@ import { EntityTypesModel, TopologyModelerInputDataFormat } from './models/entit
 import { ActivatedRoute } from '@angular/router';
 import { TopologyModelerConfiguration } from './models/topologyModelerConfiguration';
 import { ToastrService } from 'ngx-toastr';
-import { TopologyRendererState } from './redux/reducers/topologyRenderer.reducer';
+import { PossibleResearchPlugins, TopologyRendererState } from './redux/reducers/topologyRenderer.reducer';
 import { VersionElement } from './models/versionElement';
 import { TopologyRendererActions } from './redux/actions/topologyRenderer.actions';
 import { WineryRepositoryConfigurationService } from '../../../tosca-management/src/app/wineryFeatureToggleModule/WineryRepositoryConfiguration.service';
 import { WineryActions } from './redux/actions/winery.actions';
+import { DetailsSidebarState } from './sidebars/node-details/node-details-sidebar';
 
 /**
  * This is the root component of the topology modeler.
@@ -54,13 +55,15 @@ export class WineryComponent implements OnInit, AfterViewInit {
     subscriptions: Array<Subscription> = [];
     someNodeMissingCoordinates = false;
 
-    // This variable is set via the topologyModelerData input and decides if the editing functionalities are enabled
-    readonly: boolean;
-    refiningType: string;
-
     topologyDifferences: [ToscaDiff, TTopologyTemplate];
 
     detailsSidebarVisible: boolean;
+    pluginsSidebarVisible = true;
+
+    activeResearchPlugin: PossibleResearchPlugins = undefined;
+
+    // This variable is set via the topologyModelerData input and decides if the editing functionalities are enabled
+    readonly: boolean;
 
     showVersionSlider: boolean;
 
@@ -82,7 +85,14 @@ export class WineryComponent implements OnInit, AfterViewInit {
         this.subscriptions.push(this.ngRedux.select(state => state.topologyRendererState)
             .subscribe(currentButtonsState => this.setButtonsState(currentButtonsState)));
         this.subscriptions.push(this.ngRedux.select(state => state.wineryState.sidebarContents.visible)
-            .subscribe(detailsSidebarVisible => this.detailsSidebarVisible = detailsSidebarVisible));
+            .subscribe(detailsSidebarVisible => {
+                // prevent opening sidebar if research plugin is active
+                if (!this.activeResearchPlugin) {
+                    this.detailsSidebarVisible = detailsSidebarVisible;
+                }
+            }));
+        this.subscriptions.push(this.ngRedux.select(state => state.topologyRendererState.activeResearchPlugin)
+            .subscribe(activeResearchPlugin => this.activeResearchPlugin = activeResearchPlugin));
     }
 
     /**
@@ -146,22 +156,8 @@ export class WineryComponent implements OnInit, AfterViewInit {
     notifyClose(key: string): void {
         // FIXME this currently basically only supports the node-details sidebar
         //  because none of the other sidebars are based off ng-sidebar
-        this.ngRedux.dispatch(this.uiActions.openSidebar({
-            sidebarContents: {
-                visible: false,
-                nodeClicked: '',
-                template: {
-                    id: '',
-                    name: '',
-                    type: '',
-                    properties: { kvproperties: { foo: 'bar' } },
-                },
-                minInstances: -1,
-                maxInstances: -1,
-                source: '',
-                target: '',
-            }
-        }));
+        this.ngRedux.dispatch(this.uiActions.triggerSidebar(
+            { sidebarContents: new DetailsSidebarState(false) }));
     }
 
     initTopologyTemplateForRendering(nodeTemplateArray: Array<TNodeTemplate>, relationshipTemplateArray: Array<TRelationshipTemplate>) {
@@ -217,15 +213,6 @@ export class WineryComponent implements OnInit, AfterViewInit {
     }
 
     private setButtonsState(currentButtonsState: TopologyRendererState) {
-        if (currentButtonsState.buttonsState.refineTopologyButton) {
-            this.refiningType = 'topology';
-        } else if (currentButtonsState.buttonsState.refinePatternsButton) {
-            this.refiningType = 'patterns';
-        } else if (currentButtonsState.buttonsState.refineTopologyWithTestsButton) {
-            this.refiningType = 'tests';
-        } else {
-            delete this.refiningType;
-        }
         this.showVersionSlider = currentButtonsState.buttonsState.versionSliderButton;
     }
 }

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/winery.module.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/winery.module.ts
@@ -67,6 +67,7 @@ import { NgxSliderModule } from '@angular-slider/ngx-slider';
 import { VersionSliderService } from './version-slider/version-slider.service';
 import { MultiParticipantsService } from './services/multi-participants.service';
 import { ManageParticipantsComponent } from './participants/manage-participants.component';
+import { ResearchPluginsComponent } from './sidebars/research-plugins/research-plugins.component';
 
 @NgModule({
     declarations: [
@@ -83,6 +84,7 @@ import { ManageParticipantsComponent } from './participants/manage-participants.
         GroupViewComponent,
         GroupViewPoliciesComponent,
         ManageParticipantsComponent,
+        ResearchPluginsComponent,
     ],
     exports: [WineryComponent],
     imports: [


### PR DESCRIPTION
Signed-off-by: Felix Burk <felix.burk@googlemail.com>

The proposed changes implement a new sidebar which contains research plugins. 
If the new sidebar is activated - the already existing sidebar which contains Node Type information can not be triggered.

Furthermore, some cleanup of the existing sidebar is included.

- Start and end date: 2020-12-29 to 2020-12-29
- Contributor: Felix Burk @FlxB2 
- Supervisor: Michael Wurster @miwurster 


Screenshot of the new Sidebar:

![sidebar](https://user-images.githubusercontent.com/7521847/103277028-5a2b3500-49c8-11eb-8aac-7d3e6375bc64.png)


- [x] Ensure that you followed http://eclipse.github.io/winery/dev/ToolChain#github---prepare-pull-request.
- [x] Branch name checked. That means, the branch name starts with `thesis/`, `fix/`, ...
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [x] Screenshots added (for UI changes)
