### PR TITLE
Add a namespace check when searching for palette icons

### DIFF
--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/models/topologyTemplateUtil.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/models/topologyTemplateUtil.ts
@@ -195,8 +195,8 @@ export abstract class TopologyTemplateUtil {
     static getNodeVisualsForNodeTemplate(nodeType: string, nodeVisuals: Visuals[], state?: DifferenceStates): Visuals {
         for (const visual of nodeVisuals) {
             const qName = new QName(visual.typeId);
-            const localName = qName.localName;
-            if (localName === new QName(nodeType).localName) {
+            const nodeTypeQName = new QName(nodeType);
+            if (qName.localName === nodeTypeQName.localName && qName.nameSpace === nodeTypeQName.nameSpace) {
                 const color = !state ? visual.color : VersionUtils.getElementColorByDiffState(state);
                 return <Visuals>{
                     color: color,


### PR DESCRIPTION
This fix adds a namespace check when retrieving visuals for a Node Template. This prevents having wrong icons for NTs with the same name but different namespaces, e.g., nodes.aws.Platform vs nodes.ibm.Platform

- [x] Ensure that you followed our [toolchain guide](https://github.com/eclipse/winery/blob/master/docs/dev/github-workflow.md#github---prepare-final-pull-request).
- [x] Branch name checked. That means, the branch name starts with `thesis/`, `fix/`, ...
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [ ] Ensure that you appear in `NOTICE` at Copyright Holders
- [ ] Tests created for changes
- [ ] Documentation updated (if needed)
- [ ] Screenshots added (for UI changes)
