### PR TITLE
Fixes the loss of focus for KV Properties

### DIFF
--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/properties/kv-properties/kv-properties.component.html
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/properties/kv-properties/kv-properties.component.html
@@ -1,5 +1,5 @@
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (c) 2020 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2020-2023 Contributors to the Eclipse Foundation
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.
@@ -24,7 +24,7 @@
         <th>
             Values
         </th>
-    <tr *ngFor="let key of nodeProperties | keysPipe">
+    <tr *ngFor="let key of nodeProperties | keysPipe; let i = index; trackBy: trackByFn">
         <td class="">{{key.key}}</td>
         <td class="">
                 <textarea

--- a/org.eclipse.winery.frontends/app/topologymodeler/src/app/properties/kv-properties/kv-properties.component.ts
+++ b/org.eclipse.winery.frontends/app/topologymodeler/src/app/properties/kv-properties/kv-properties.component.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020-2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -162,6 +162,10 @@ export class KvPropertiesComponent implements OnInit, OnDestroy {
         } finally {
             this.checkForErrors();
         }
+    }
+
+    trackByFn(index, item) {
+        return index;
     }
 
     checkAndSetPattern(key: string, value: string): void {


### PR DESCRIPTION
Fixes the loosing of focus for KV Properties in the topology modeler

- [x] Ensure that you followed our [toolchain guide](https://github.com/eclipse/winery/blob/main/docs/dev/github-workflow.md#github---prepare-final-pull-request). Especially, we require **a single commit**
- [x] Ensure that the commit message is [a good commit message](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Ensure to use auto format in **all** files
- [x] Ensure that you appear in `NOTICE` at Copyright Holders
