### PR TITLE
GitHub registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,12 +113,12 @@ jobs:
           platforms: amd64,arm64,arm
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta-cli
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cli
       - name: Set up Docker Buildx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
-      docker_run_required: ${{ true }} # ${{ (github.repository_owner == 'OpenTOSCA' && (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags'))) }}
+      docker_run_required: ${{ (github.repository_owner == 'OpenTOSCA' && (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags'))) }}
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
       - "v*.*.*"
   pull_request:
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
 
   pre_job:
@@ -15,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
-      docker_run_required: ${{ (github.repository_owner == 'OpenTOSCA' && (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags'))) }}
+      docker_run_required: ${{ true }} # ${{ (github.repository_owner == 'OpenTOSCA' && (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags'))) }}
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
@@ -107,41 +111,39 @@ jobs:
         uses: docker/setup-qemu-action@v2
         with:
           platforms: amd64,arm64,arm
-      - name: Set variables
-        id: vars
-        run: |
-          DOCKER_IMAGE=opentosca/winery
-          VERSION=latest
-          SHORTREF=${GITHUB_SHA::8}
-
-          # If this is git tag, use the tag name
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
-          fi
-          TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${SHORTREF}"
-
-          # Set output parameters.
-          echo ::set-output name=tags::${TAGS}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta-cli
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cli
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push latest Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: Dockerfile.noBuild
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.vars.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
       - name: Build and push latest CLI Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: Dockerfile.cli
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: 'opentosca/winery-cli:latest'
+          tags: ${{ steps.meta-cli.outputs.tags }}
+          labels: ${{ steps.meta-cli.outputs.labels }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cli
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
+      - name: Login to GitHub registry
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}


### PR DESCRIPTION
This PR replaces Docker Hub with the GitHub registry in the GitHub workflow and updates the used GitHub actions.

Needed for https://github.com/OpenTOSCA/opentosca-docker/pull/57