### PR TITLE
Publish Maven package to GitHub packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
     tags:
       - "v*.*.*"
   pull_request:
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -45,6 +46,10 @@ jobs:
           distribution: 'temurin'
           java-version: 17
           cache: 'maven'
+      - name: Publish package
+        run: mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with Maven
         run: mvn -Pjava -B package
       - name: Upload binary to artifacts

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,13 @@
         <url>https://www.eclipse.org/winery</url>
     </organization>
     <inceptionYear>2012</inceptionYear>
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/octocat/hello-world</url>
+        </repository>
+    </distributionManagement>
     <mailingLists>
         <mailingList>
             <name>Winery Developer List</name>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/PhilWun/winery</url>
+            <url>https://maven.pkg.github.com/OpenTOSCA/winery</url>
         </repository>
     </distributionManagement>
     <mailingLists>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/octocat/hello-world</url>
+            <url>https://maven.pkg.github.com/PhilWun/winery</url>
         </repository>
     </distributionManagement>
     <mailingLists>


### PR DESCRIPTION
This PR extends the GitHub workflow to publish the package to GitHub packages. This is needed as an alternative to jitpack which currently causes problems: https://github.com/OpenTOSCA/container/issues/317
